### PR TITLE
fix trac 9544: gcc 4.9.0 -std=c++1y breakage

### DIFF
--- a/include/boost/regex/v4/basic_regex_creator.hpp
+++ b/include/boost/regex/v4/basic_regex_creator.hpp
@@ -344,7 +344,7 @@ re_literal* basic_regex_creator<charT, traits>::append_literal(charT c)
       m_last_state = result = static_cast<re_literal*>(getaddress(off));
       charT* characters = static_cast<charT*>(static_cast<void*>(result+1));
       characters[result->length] = m_traits.translate(c, m_icase);
-      ++(result->length);
+      result->length += 1;
    }
    return result;
 }

--- a/include/boost/regex/v4/basic_regex_parser.hpp
+++ b/include/boost/regex/v4/basic_regex_parser.hpp
@@ -971,7 +971,7 @@ bool basic_regex_parser<charT, traits>::parse_repeat(std::size_t low, std::size_
       // the last state was a literal with more than one character, split it in two:
       re_literal* lit = static_cast<re_literal*>(this->m_last_state);
       charT c = (static_cast<charT*>(static_cast<void*>(lit+1)))[lit->length - 1];
-      --(lit->length);
+      lit->length -= 1;
       // now append new state:
       lit = static_cast<re_literal*>(this->append_state(syntax_element_literal, sizeof(re_literal) + sizeof(charT)));
       lit->length = 1;


### PR DESCRIPTION
This is GCC bug PR C++/59681 but the Boost fix is trivial and the GCC
one is (probably) not.

See: http://gcc.gnu.org/bugzilla/show_bug.cgi?id=59681
