### PR TITLE
Update regex_raw_buffer.hpp

### DIFF
--- a/include/boost/regex/v4/regex_raw_buffer.hpp
+++ b/include/boost/regex/v4/regex_raw_buffer.hpp
@@ -129,7 +129,7 @@ public:
    {
       if(size_type(last - end) < n)
          resize(n + (end - start));
-      register pointer result = end;
+      pointer result = end;
       end += n;
       return result;
    }


### PR DESCRIPTION
Removed compiler hint 'register'.

'register' has been deprecated in the ISO C++ Standard - Annex D.2
See: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3690.pdf#appendix.D
