### PR TITLE
Remove register storage specifier

### DIFF
--- a/include/boost/regex/v4/regex_raw_buffer.hpp
+++ b/include/boost/regex/v4/regex_raw_buffer.hpp
@@ -129,7 +129,7 @@ public:
    {
       if(size_type(last - end) < n)
          resize(n + (end - start));
-      register pointer result = end;
+      pointer result = end;
       end += n;
       return result;
    }


### PR DESCRIPTION
Remove register storage specifier to silence clang warnings "'register' storage class specifier is deprecated".
