### PR TITLE
Turn warnings to 'on' for clang to avoid Boost PP warnings.

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -8,6 +8,7 @@ import modules ;
 project : requirements
    # default to all warnings on:
    <warnings>all
+   <toolset>clang:<warnings>on
    ;
 
 local disable-icu = [ MATCH (--disable-icu) : [ modules.peek : ARGV ] ] ;


### PR DESCRIPTION
If warnings are 'all' many clang warnings in Boost PP occur.
