### PR TITLE
Initialize start_pos in repeater_count constructor

### DIFF
--- a/include/boost/regex/v4/perl_matcher.hpp
+++ b/include/boost/regex/v4/perl_matcher.hpp
@@ -255,6 +255,7 @@ class repeater_count
    BidiIterator start_pos;   // where the last repeat started
 public:
    repeater_count(repeater_count** s)
+      : start_pos()
    {
       stack = s;
       next = 0;


### PR DESCRIPTION
start_pos is otherwise uninitialized leaving this constructor. Uncovered by Coverity, this issue has CID10549.
