### PR TITLE
Initialize m_null and m_base

### DIFF
--- a/include/boost/regex/v4/match_results.hpp
+++ b/include/boost/regex/v4/match_results.hpp
@@ -76,30 +76,20 @@ public:
    // construct/copy/destroy:
    explicit match_results(const Allocator& a = Allocator())
 #ifndef BOOST_NO_STD_ALLOCATOR
-      : m_subs(a), m_base(), m_last_closed_paren(0), m_is_singular(true) {}
+      : m_subs(a), m_base(), m_null(), m_last_closed_paren(0), m_is_singular(true) {}
 #else
-      : m_subs(), m_base(), m_last_closed_paren(0), m_is_singular(true) { (void)a; }
+      : m_subs(), m_base(), m_null(), m_last_closed_paren(0), m_is_singular(true) { (void)a; }
 #endif
    match_results(const match_results& m)
-      : m_subs(m.m_subs), m_named_subs(m.m_named_subs), m_last_closed_paren(m.m_last_closed_paren), m_is_singular(m.m_is_singular) 
-   {
-      if(!m_is_singular)
-      {
-         m_base = m.m_base;
-         m_null = m.m_null;
-      }
-   }
+      : m_subs(m.m_subs), m_base(m.m_base), m_null(m.m_null), m_named_subs(m.m_named_subs), m_last_closed_paren(m.m_last_closed_paren), m_is_singular(m.m_is_singular) {}
    match_results& operator=(const match_results& m)
    {
       m_subs = m.m_subs;
       m_named_subs = m.m_named_subs;
       m_last_closed_paren = m.m_last_closed_paren;
       m_is_singular = m.m_is_singular;
-      if(!m_is_singular)
-      {
-         m_base = m.m_base;
-         m_null = m.m_null;
-      }
+      m_base = m.m_base;
+      m_null = m.m_null;
       return *this;
    }
    ~match_results(){}
@@ -410,24 +400,8 @@ public:
       std::swap(m_subs, that.m_subs);
       std::swap(m_named_subs, that.m_named_subs);
       std::swap(m_last_closed_paren, that.m_last_closed_paren);
-      if(m_is_singular)
-      {
-         if(!that.m_is_singular)
-         {
-            m_base = that.m_base;
-            m_null = that.m_null;
-         }
-      }
-      else if(that.m_is_singular)
-      {
-         that.m_base = m_base;
-         that.m_null = m_null;
-      }
-      else
-      {
-         std::swap(m_base, that.m_base);
-         std::swap(m_null, that.m_null);
-      }
+      std::swap(m_base, that.m_base);
+      std::swap(m_null, that.m_null);
       std::swap(m_is_singular, that.m_is_singular);
    }
    bool operator==(const match_results& that)const


### PR DESCRIPTION
In the cases where we were not initializing m_null and m_base, instead we initialize them to default values. This simplifies the logic around assigning to them significantly and silences Coverity CID10550.
