### PR TITLE
Initialize m_position, m_end, and m_flags

### DIFF
--- a/include/boost/regex/v4/regex_format.hpp
+++ b/include/boost/regex/v4/regex_format.hpp
@@ -96,7 +96,7 @@ class basic_regex_formatter
 public:
    typedef typename traits::char_type char_type;
    basic_regex_formatter(OutputIterator o, const Results& r, const traits& t)
-      : m_traits(t), m_results(r), m_out(o), m_state(output_copy), m_restore_state(output_copy), m_have_conditional(false) {}
+      : m_traits(t), m_results(r), m_out(o), m_position(), m_end(), m_flags(), m_state(output_copy), m_restore_state(output_copy), m_have_conditional(false) {}
    OutputIterator format(ForwardIter p1, ForwardIter p2, match_flag_type f);
    OutputIterator format(ForwardIter p1, match_flag_type f)
    {


### PR DESCRIPTION
The constructor for basic_regex_formatter left m_position, m_end, and m_flags uninitialized, as uncovered by Coverity CID12310. We now value-initialize them in the initializer list.
