### PR TITLE
Only specify debug library name for msvc and intel

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -60,9 +60,9 @@ if ! $(disable-icu)
 
       lib icuin : :                                                    <name>icui18n <link>shared <runtime-link>shared <conditional>@path_options ;
       lib icuin : : <toolset>msvc                     <variant>debug   <name>icuind  <link>shared <runtime-link>shared <conditional>@path_options ;
-      lib icuin : : <toolset>msvc                     <variant>release <name>icuin   <link>shared <runtime-link>shared <conditional>@path_options ;
+      lib icuin : : <toolset>msvc                                      <name>icuin   <link>shared <runtime-link>shared <conditional>@path_options ;
       lib icuin : : <toolset>intel <target-os>windows <variant>debug   <name>icuind  <link>shared <runtime-link>shared <conditional>@path_options ;
-      lib icuin : : <toolset>intel <target-os>windows <variant>release <name>icuin   <link>shared <runtime-link>shared <conditional>@path_options ;
+      lib icuin : : <toolset>intel <target-os>windows                  <name>icuin   <link>shared <runtime-link>shared <conditional>@path_options ;
       lib icuin : : <name>this_is_an_invalid_library_name ;
 
       if $(ICU_PATH)


### PR DESCRIPTION
Boost.Build can then fallback to the release libraries for these
compilers for user-defined variants.