### PR TITLE
make sub_match usable with Boost.Range

### DIFF
--- a/include/boost/regex/v4/sub_match.hpp
+++ b/include/boost/regex/v4/sub_match.hpp
@@ -188,6 +188,30 @@ typedef sub_match<const wchar_t*> wcsub_match;
 typedef sub_match<std::wstring::const_iterator> wssub_match;
 #endif
 
+template <typename BidiIterator>
+inline typename sub_match<BidiIterator>::iterator range_begin(sub_match<BidiIterator>& m)
+{
+   return m.first;
+}
+
+template <typename BidiIterator>
+inline typename sub_match<BidiIterator>::const_iterator range_begin(const sub_match<BidiIterator>& m)
+{
+   return m.first;
+}
+
+template <typename BidiIterator>
+inline typename sub_match<BidiIterator>::iterator range_end(sub_match<BidiIterator>& m)
+{
+   return m.second;
+}
+
+template <typename BidiIterator>
+inline typename sub_match<BidiIterator>::const_iterator range_end(const sub_match<BidiIterator>& m)
+{
+   return m.second;
+}
+
 // comparison to std::basic_string<> part 1:
 template <class RandomAccessIterator, class traits, class Allocator>
 inline bool operator == (const std::basic_string<typename re_detail::regex_iterator_traits<RandomAccessIterator>::value_type, traits, Allocator>& s,


### PR DESCRIPTION
This implements this suggestion, i.e. it makes sub_match usable as a range in the least intrusive way: https://svn.boost.org/trac/boost/ticket/11036