### PR TITLE
Add re2 and pcre jit performance test and other fixes

### DIFF
--- a/doc/gcc-performance.html
+++ b/doc/gcc-performance.html
@@ -1,543 +1,142 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2//EN">
 <html>
    <head>
-      <title>Regular Expression Performance Comparison (gcc 3.2)</title>
-      <meta name="generator" content="HTML Tidy, see www.w3.org">
+      <title>Regular Expression Performance Comparison</title>
       <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
       <meta name="vs_targetSchema" content="http://schemas.microsoft.com/intellisense/ie5">
-      <META content="C:\PROGRAM FILES\MICROSOFT OFFICE\OFFICE\html.dot" name="Template">
+      <meta name="Template" content="C:\PROGRAM FILES\MICROSOFT OFFICE\OFFICE\html.dot">
       <meta name="GENERATOR" content="Microsoft FrontPage Express 2.0">
+      <!-- boostinspect:nounlinked -->
    </head>
    <body bgcolor="#ffffff" link="#0000ff" vlink="#800080">
       <h2>Regular Expression Performance Comparison</h2>
-      <p>The following tables provide comparisons between the following regular 
+      <p>
+         The following tables provide comparisons between the following regular 
          expression libraries:</p>
+      <p><a href="http://research.microsoft.com/projects/greta">GRETA</a>.</p>
       <p><a href="http://www.boost.org/">The Boost regex library</a>.</p>
-      <p><a href="http://www.gnu.org">The GNU regular expression library</a>.</p>
-      <p>Philip Hazel's <a href="http://www.pcre.org">PCRE</a> library.</p>
-      <h3>Details</h3>
-      <p>Machine: Intel Pentium 4 2.8GHz PC.</p>
-      <p>Compiler: GNU C++ version 3.2 20020927 (prerelease).</p>
-      <p>C++ Standard Library: GNU libstdc++ version 20020927.</p>
-      <p>OS: Cygwin.</p>
-      <p>Boost version: 1.31.0.</p>
-      <p>PCRE version: 4.1.</p>
-      <p>As ever care should be taken in interpreting the results, only sensible regular 
+      <p><a href="http://arglist.com/regex/">Henry Spencer's regular expression library</a>
+         - this is provided for comparison as a typical non-backtracking implementation.</p>
+      <P>Philip Hazel's <A href="http://www.pcre.org">PCRE</A> library.</P>
+      <H3>Details</H3>
+      <P>Machine: Intel Xeon E5405 2.0GHz Server.</P>
+      <P>Compiler: GNU C++ version 4.4.7 20120313 (Red Hat 4.4.7-4).</P>
+      <P>C++ Standard Library: GNU libstdc++ version 20120313.</P>
+      <P>OS: CentOS 6.4.</P>
+      <P>Boost version: 1.56.0.</P>
+      <P>PCRE version: 8.37.</P>
+      <P>
+         As ever care should be taken in interpreting the results, only sensible regular 
          expressions (rather than pathological cases) are given, most are taken from the 
          Boost regex examples, or from the <a href="http://www.regxlib.com/">Library of 
             Regular Expressions</a>. In addition, some variation in the relative 
          performance of these libraries can be expected on other machines - as memory 
          access and processor caching effects can be quite large for most finite state 
-         machine algorithms. In each case the first figure given is the relative time 
-         taken (so a value of 1.0 is as good as it gets), while the second figure is the 
-         actual time taken.</p>
-      <h3>Averages</h3>
-      <p>The following are the average relative scores for all the tests: the perfect 
+         machine algorithms.</P>
+      <H3>Averages</H3>
+      <P>The following are the average relative scores for all the tests: the perfect 
          regular expression library&nbsp;would score 1, in practice anything less than 2 
-         is pretty good.</p>
-      <table border="1" cellspacing="1">
-         <tr>
-            <td><strong>Boost</strong></td>
-            <td><strong>Boost + C++ locale</strong></td>
-            <td><strong>POSIX</strong></td>
-            <td><strong>PCRE</strong></td>
-         </tr>
-         <tr>
-            <td>1.4503</td>
-            <td>1.49124</td>
-            <td>108.372</td>
-            <td>1.56255</td>
-         </tr>
-      </table>
-      <br>
-      <br>
+         is pretty good.</P>
+      <P><table border="1" cellspacing="1">
+<tr><td><strong>GRETA</strong></td><td><strong>GRETA<BR>(non-recursive mode)</strong></td><td><strong>Boost</strong></td><td><strong>Boost + C++ locale</strong></td><td><strong>POSIX</strong></td><td><strong>PCRE</strong></td><td><strong>PCRE JIT</strong></td><td><strong>Dynamic Xpressive</strong></td><td><strong>google RE2</strong></td></tr>
+<tr><td>5.01504</td>
+<td>8.36469</td>
+<td>5.77755</td>
+<td>5.73107</td>
+<td>12.8016</td>
+<td>4.81298</td>
+<td>1.42227</td>
+<td>3.86712</td>
+<td>3.74945</td>
+</tr>
+</table>
+</P>
       <h3>Comparison 1: Long Search</h3>
       <p>For each of the following regular expressions the time taken to find all 
          occurrences of the expression within a long English language text was measured 
          (<a href="http://www.gutenberg.org/files/3200/old/mtent12.zip">mtent12.txt</a>
          from <a href="http://promo.net/pg/">Project Gutenberg</a>, 19Mb).&nbsp;</p>
-      <table border="1" cellspacing="1">
-         <tr>
-            <td><strong>Expression</strong></td>
-            <td><strong>Boost</strong></td>
-            <td><strong>Boost + C++ locale</strong></td>
-            <td><strong>POSIX</strong></td>
-            <td><strong>PCRE</strong></td>
-         </tr>
-         <tr>
-            <td><code>Twain</code></td>
-            <td>3.49<br>
-               (0.205s)</td>
-            <td>4.09<br>
-               (0.24s)</td>
-            <td>65.2<br>
-               (3.83s)</td>
-            <td><font color="#008000">1<br>
-                  (0.0588s)</font></td>
-         </tr>
-         <tr>
-            <td><code>Huck[[:alpha:]]+</code></td>
-            <td>3.86<br>
-               (0.203s)</td>
-            <td>4.52<br>
-               (0.238s)</td>
-            <td>100<br>
-               (5.26s)</td>
-            <td><font color="#008000">1<br>
-                  (0.0526s)</font></td>
-         </tr>
-         <tr>
-            <td><code>[[:alpha:]]+ing</code></td>
-            <td><font color="#008000">1.01<br>
-                  (1.23s)</font></td>
-            <td><font color="#008000">1<br>
-                  (1.22s)</font></td>
-            <td>4.95<br>
-               (6.04s)</td>
-            <td>4.67<br>
-               (5.71s)</td>
-         </tr>
-         <tr>
-            <td><code>^[^ ]*?Twain</code></td>
-            <td><font color="#008000">1<br>
-                  (0.31s)</font></td>
-            <td><font color="#008000">1.05<br>
-                  (0.326s)</font></td>
-            <td>NA</td>
-            <td>3.32<br>
-               (1.03s)</td>
-         </tr>
-         <tr>
-            <td><code>Tom|Sawyer|Huckleberry|Finn</code></td>
-            <td><font color="#008000">1.02<br>
-                  (0.125s)</font></td>
-            <td><font color="#008000">1<br>
-                  (0.123s)</font></td>
-            <td>165<br>
-               (20.3s)</td>
-            <td><font color="#008000">1.08<br>
-                  (0.133s)</font></td>
-         </tr>
-         <tr>
-            <td><code> (Tom|Sawyer|Huckleberry|Finn).{0,30}river|river.{0,30}(Tom|Sawyer|Huckleberry|Finn)</code></td>
-            <td><font color="#008000">1<br>
-                  (0.345s)</font></td>
-            <td><font color="#008000">1.03<br>
-                  (0.355s)</font></td>
-            <td>NA</td>
-            <td>1.71<br>
-               (0.59s)</td>
-         </tr>
-      </table>
-      <br>
-      <br>
+      <P><table border="1" cellspacing="1">
+<tr><td><strong>Expression</strong></td><td><strong>GRETA</strong></td><td><strong>GRETA<BR>(non-recursive mode)</strong></td><td><strong>Boost</strong></td><td><strong>Boost + C++ locale</strong></td><td><strong>POSIX</strong></td><td><strong>PCRE</strong></td><td><strong>PCRE JIT</strong></td><td><strong>Dynamic Xpressive</strong></td><td><strong>RE2</strong></td></tr>
+<tr><td><code>Twain</code></td><td>3.64<BR>(0.0256s)</td><td>3.64<BR>(0.0256s)</td><td>4.98<BR>(0.035s)</td><td>5.16<BR>(0.0362s)</td><td>3.96<BR>(0.0278s)</td><td>4.8<BR>(0.0338s)</td><td>2.84<BR>(0.02s)</td><td>3.64<BR>(0.0256s)</td><td><font color="#008000">1<BR>(0.00703s)</font></td></tr>
+<tr><td><code>Huck[[:alpha:]]+</code></td><td>4.96<BR>(0.0259s)</td><td>4.96<BR>(0.0259s)</td><td>6.45<BR>(0.0338s)</td><td>6.33<BR>(0.0331s)</td><td>4.9<BR>(0.0256s)</td><td>6.09<BR>(0.0319s)</td><td>3.7<BR>(0.0194s)</td><td>4.78<BR>(0.025s)</td><td><font color="#008000">1<BR>(0.00523s)</font></td></tr>
+<tr><td><code>[[:alpha:]]+ing</code></td><td>10.4<BR>(1.46s)</td><td>19<BR>(2.66s)</td><td>3.5<BR>(0.49s)</td><td>3.57<BR>(0.5s)</td><td>8.43<BR>(1.18s)</td><td>14.2<BR>(1.99s)</td><td>4.5<BR>(0.63s)</td><td>3.11<BR>(0.435s)</td><td><font color="#008000">1<BR>(0.14s)</font></td></tr>
+<tr><td><code>^[^
+]*?Twain</code></td><td>5.61<BR>(0.47s)</td><td>20.4<BR>(1.71s)</td><td>2.69<BR>(0.225s)</td><td>2.69<BR>(0.225s)</td><td>NA</td><td>4.96<BR>(0.415s)</td><td>1.24<BR>(0.104s)</td><td>2.84<BR>(0.237s)</td><td><font color="#008000">1<BR>(0.0838s)</font></td></tr>
+<tr><td><code>Tom|Sawyer|Huckleberry|Finn</code></td><td>6.94<BR>(0.23s)</td><td>13.4<BR>(0.445s)</td><td>1.38<BR>(0.0456s)</td><td>1.36<BR>(0.045s)</td><td><font color="#008000">1<BR>(0.0331s)</font></td><td>2<BR>(0.0663s)</td><td>1.6<BR>(0.0531s)</td><td>1.45<BR>(0.0481s)</td><td>2.53<BR>(0.0838s)</td></tr>
+<tr><td><code>(Tom|Sawyer|Huckleberry|Finn).{0,30}river|river.{0,30}(Tom|Sawyer|Huckleberry|Finn)</code></td><td>5.71<BR>(0.45s)</td><td>6.86<BR>(0.54s)</td><td>1.44<BR>(0.114s)</td><td>1.48<BR>(0.116s)</td><td>1.43<BR>(0.113s)</td><td>2.6<BR>(0.205s)</td><td><font color="#008000">1<BR>(0.0788s)</font></td><td>1.3<BR>(0.102s)</td><td><font color="#008000">1.05<BR>(0.0825s)</font></td></tr>
+</table>
+</P>
       <h3>Comparison 2: Medium Sized Search</h3>
       <p>For each of the following regular expressions the time taken to find all 
          occurrences of the expression within a medium sized English language text was 
-         measured (the first 50K from mtent12.txt).&nbsp;</p>
-      <table border="1" cellspacing="1">
-         <tr>
-            <td><strong>Expression</strong></td>
-            <td><strong>Boost</strong></td>
-            <td><strong>Boost + C++ locale</strong></td>
-            <td><strong>POSIX</strong></td>
-            <td><strong>PCRE</strong></td>
-         </tr>
-         <tr>
-            <td><code>Twain</code></td>
-            <td>1.8<br>
-               (0.000519s)</td>
-            <td>2.14<br>
-               (0.000616s)</td>
-            <td>9.08<br>
-               (0.00262s)</td>
-            <td><font color="#008000">1<br>
-                  (0.000289s)</font></td>
-         </tr>
-         <tr>
-            <td><code>Huck[[:alpha:]]+</code></td>
-            <td>3.65<br>
-               (0.000499s)</td>
-            <td>4.36<br>
-               (0.000597s)</td>
-            <td><font color="#008000">1<br>
-                  (0.000137s)</font></td>
-            <td>1.43<br>
-               (0.000196s)</td>
-         </tr>
-         <tr>
-            <td><code>[[:alpha:]]+ing</code></td>
-            <td><font color="#008000">1<br>
-                  (0.00258s)</font></td>
-            <td><font color="#008000">1<br>
-                  (0.00258s)</font></td>
-            <td>5.28<br>
-               (0.0136s)</td>
-            <td>5.63<br>
-               (0.0145s)</td>
-         </tr>
-         <tr>
-            <td><code>^[^ ]*?Twain</code></td>
-            <td><font color="#008000">1<br>
-                  (0.000929s)</font></td>
-            <td><font color="#008000">1.03<br>
-                  (0.000957s)</font></td>
-            <td>NA</td>
-            <td>2.82<br>
-               (0.00262s)</td>
-         </tr>
-         <tr>
-            <td><code>Tom|Sawyer|Huckleberry|Finn</code></td>
-            <td><font color="#008000">1<br>
-                  (0.000812s)</font></td>
-            <td><font color="#008000">1<br>
-                  (0.000812s)</font></td>
-            <td>60.1<br>
-               (0.0488s)</td>
-            <td>1.28<br>
-               (0.00104s)</td>
-         </tr>
-         <tr>
-            <td><code> (Tom|Sawyer|Huckleberry|Finn).{0,30}river|river.{0,30}(Tom|Sawyer|Huckleberry|Finn)</code></td>
-            <td><font color="#008000">1.02<br>
-                  (0.00178s)</font></td>
-            <td><font color="#008000">1<br>
-                  (0.00174s)</font></td>
-            <td>242<br>
-               (0.421s)</td>
-            <td>1.3<br>
-               (0.00227s)</td>
-         </tr>
-      </table>
-      <br>
-      <br>
-      <h3>Comparison 3:&nbsp;C++ Code&nbsp;Search</h3>
-      <p>For each of the following regular expressions the time taken to find all 
-         occurrences of the expression within the C++ source file <a href="../../../boost/crc.hpp">
-            boost/crc.hpp</a>&nbsp;was measured.&nbsp;</p>
-      <table border="1" cellspacing="1">
-         <tr>
-            <td><strong>Expression</strong></td>
-            <td><strong>Boost</strong></td>
-            <td><strong>Boost + C++ locale</strong></td>
-            <td><strong>POSIX</strong></td>
-            <td><strong>PCRE</strong></td>
-         </tr>
-         <tr>
-            <td><code> ^(template[[:space:]]*&lt;[^;:{]+&gt;[[:space:]]*)?(class|struct)[[:space:]]*(\&lt;\w+\&gt;([ 
-                  ]*\([^)]*\))?[[:space:]]*)*(\&lt;\w*\&gt;)[[:space:]]*(&lt;[^;:{]+&gt;[[:space:]]*)?(\{|:[^;\{()]*\{)</code></td>
-            <td><font color="#008000">1.04<br>
-                  (0.000144s)</font></td>
-            <td><font color="#008000">1<br>
-                  (0.000139s)</font></td>
-            <td>862<br>
-               (0.12s)</td>
-            <td>4.56<br>
-               (0.000636s)</td>
-         </tr>
-         <tr>
-            <td><code>(^[ 
-                  ]*#(?:[^\\\n]|\\[^\n_[:punct:][:alnum:]]*[\n[:punct:][:word:]])*)|(//[^\n]*|/\*.*?\*/)|\&lt;([+-]?(?:(?:0x[[:xdigit:]]+)|(?:(?:[[:digit:]]*\.)?[[:digit:]]+(?:[eE][+-]?[[:digit:]]+)?))u?(?:(?:int(?:8|16|32|64))|L)?)\&gt;|('(?:[^\\']|\\.)*'|"(?:[^\\"]|\\.)*")|\&lt;(__asm|__cdecl|__declspec|__export|__far16|__fastcall|__fortran|__import|__pascal|__rtti|__stdcall|_asm|_cdecl|__except|_export|_far16|_fastcall|__finally|_fortran|_import|_pascal|_stdcall|__thread|__try|asm|auto|bool|break|case|catch|cdecl|char|class|const|const_cast|continue|default|delete|do|double|dynamic_cast|else|enum|explicit|extern|false|float|for|friend|goto|if|inline|int|long|mutable|namespace|new|operator|pascal|private|protected|public|register|reinterpret_cast|return|short|signed|sizeof|static|static_cast|struct|switch|template|this|throw|true|try|typedef|typeid|typename|union|unsigned|using|virtual|void|volatile|wchar_t|while)\&gt;</code></td>
-            <td><font color="#008000">1<br>
-                  (0.0139s)</font></td>
-            <td><font color="#008000">1.01<br>
-                  (0.0141s)</font></td>
-            <td>NA</td>
-            <td>1.55<br>
-               (0.0216s)</td>
-         </tr>
-         <tr>
-            <td><code>^[ ]*#[ ]*include[ ]+("[^"]+"|&lt;[^&gt;]+&gt;)</code></td>
-            <td><font color="#008000">1.04<br>
-                  (0.000332s)</font></td>
-            <td><font color="#008000">1<br>
-                  (0.000318s)</font></td>
-            <td>130<br>
-               (0.0413s)</td>
-            <td>1.72<br>
-               (0.000547s)</td>
-         </tr>
-         <tr>
-            <td><code>^[ ]*#[ ]*include[ ]+("boost/[^"]+"|&lt;boost/[^&gt;]+&gt;)</code></td>
-            <td><font color="#008000">1.02<br>
-                  (0.000323s)</font></td>
-            <td><font color="#008000">1<br>
-                  (0.000318s)</font></td>
-            <td>150<br>
-               (0.0476s)</td>
-            <td>1.72<br>
-               (0.000547s)</td>
-         </tr>
-      </table>
-      <br>
-      <h3></h3>
-      <H3>Comparison 4: HTML Document Search
+         measured (the first 50K from mtent12.txt - up to the end of Chapter 1).&nbsp;</p>
+      <P><table border="1" cellspacing="1">
+<tr><td><strong>Expression</strong></td><td><strong>GRETA</strong></td><td><strong>GRETA<BR>(non-recursive mode)</strong></td><td><strong>Boost</strong></td><td><strong>Boost + C++ locale</strong></td><td><strong>POSIX</strong></td><td><strong>PCRE</strong></td><td><strong>PCRE JIT</strong></td><td><strong>Dynamic Xpressive</strong></td><td><strong>RE2</strong></td></tr>
+<tr><td><code>Twain</code></td><td>1.53<BR>(5.98e-05s)</td><td>1.56<BR>(6.1e-05s)</td><td>3.62<BR>(0.000142s)</td><td>3.62<BR>(0.000142s)</td><td>3.31<BR>(0.000129s)</td><td>3.31<BR>(0.000129s)</td><td>1.19<BR>(4.64e-05s)</td><td>1.69<BR>(6.59e-05s)</td><td><font color="#008000">1<BR>(3.91e-05s)</font></td></tr>
+<tr><td><code>Huck[[:alpha:]]+</code></td><td>3.48<BR>(6.59e-05s)</td><td>3.48<BR>(6.59e-05s)</td><td>6.06<BR>(0.000115s)</td><td>5.81<BR>(0.00011s)</td><td>4.77<BR>(9.03e-05s)</td><td>5.35<BR>(0.000101s)</td><td>2.52<BR>(4.76e-05s)</td><td>3.35<BR>(6.35e-05s)</td><td><font color="#008000">1<BR>(1.89e-05s)</font></td></tr>
+<tr><td><code>[[:alpha:]]+ing</code></td><td>12<BR>(0.00375s)</td><td>22.2<BR>(0.00695s)</td><td>3.44<BR>(0.00107s)</td><td>3.5<BR>(0.00109s)</td><td>9.25<BR>(0.00289s)</td><td>15.5<BR>(0.00484s)</td><td>5.19<BR>(0.00162s)</td><td>3.56<BR>(0.00111s)</td><td><font color="#008000">1<BR>(0.000313s)</font></td></tr>
+<tr><td><code>^[^
+]*?Twain</code></td><td>5.57<BR>(0.00121s)</td><td>16.5<BR>(0.00359s)</td><td>2.88<BR>(0.000625s)</td><td>2.88<BR>(0.000625s)</td><td>NA</td><td>5.03<BR>(0.00109s)</td><td>1.24<BR>(0.000269s)</td><td>2.97<BR>(0.000645s)</td><td><font color="#008000">1<BR>(0.000217s)</font></td></tr>
+<tr><td><code>Tom|Sawyer|Huckleberry|Finn</code></td><td>5.87<BR>(0.000674s)</td><td>11.7<BR>(0.00135s)</td><td>2.77<BR>(0.000317s)</td><td>2.77<BR>(0.000317s)</td><td>2.02<BR>(0.000232s)</td><td>3.7<BR>(0.000425s)</td><td><font color="#008000">1<BR>(0.000115s)</font></td><td>2.55<BR>(0.000293s)</td><td>1.85<BR>(0.000212s)</td></tr>
+<tr><td><code>(Tom|Sawyer|Huckleberry|Finn).{0,30}river|river.{0,30}(Tom|Sawyer|Huckleberry|Finn)</code></td><td>3.77<BR>(0.000791s)</td><td>8.09<BR>(0.0017s)</td><td>2.93<BR>(0.000615s)</td><td>2.93<BR>(0.000615s)</td><td>2.07<BR>(0.000435s)</td><td>3.86<BR>(0.000811s)</td><td>1.19<BR>(0.000249s)</td><td>2.21<BR>(0.000464s)</td><td><font color="#008000">1<BR>(0.00021s)</font></td></tr>
+</table>
+</P>
+      <H3>Comparison 3:&nbsp;C++ Code&nbsp;Search</H3>
+      <P>For each of the following regular expressions the time taken to find all 
+         occurrences of the expression within the C++ source file <A href="../../../boost/crc.hpp">
+            boost/crc.hpp</A>&nbsp;was measured.&nbsp;</P>
+      <P><table border="1" cellspacing="1">
+<tr><td><strong>Expression</strong></td><td><strong>GRETA</strong></td><td><strong>GRETA<BR>(non-recursive mode)</strong></td><td><strong>Boost</strong></td><td><strong>Boost + C++ locale</strong></td><td><strong>POSIX</strong></td><td><strong>PCRE</strong></td><td><strong>PCRE JIT</strong></td><td><strong>Dynamic Xpressive</strong></td><td><strong>RE2</strong></td></tr>
+<tr><td><code>^(template[[:space:]]*&lt;[^;:{]+&gt;[[:space:]]*)?(class|struct)[[:space:]]*(\&lt;\w+\&gt;([ 	]*\([^)]*\))?[[:space:]]*)*(\&lt;\w*\&gt;)[[:space:]]*(&lt;[^;:{]+&gt;[[:space:]]*)?(\{|:[^;\{()]*\{)</code></td><td>22.9<BR>(0.00162s)</td><td>22.9<BR>(0.00162s)</td><td>1.47<BR>(0.000104s)</td><td>1.48<BR>(0.000105s)</td><td>NA</td><td>4.41<BR>(0.000313s)</td><td><font color="#008000">1<BR>(7.08e-05s)</font></td><td>1.66<BR>(0.000117s)</td><td>1.93<BR>(0.000137s)</td></tr>
+<tr><td><code>(^[ 	]*#(?:[^\\\n]|\\[^\n_[:punct:][:alnum:]]*[\n[:punct:][:word:]])*)|(//[^\n]*|/\*.*?\*/)|\&lt;([+-]?(?:(?:0x[[:xdigit:]]+)|(?:(?:[[:digit:]]*\.)?[[:digit:]]+(?:[eE][+-]?[[:digit:]]+)?))u?(?:(?:int(?:8|16|32|64))|L)?)\&gt;|('(?:[^\\']|\\.)*'|&quot;(?:[^\\&quot;]|\\.)*&quot;)|\&lt;(__asm|__cdecl|__declspec|__export|__far16|__fastcall|__fortran|__import|__pascal|__rtti|__stdcall|_asm|_cdecl|__except|_export|_far16|_fastcall|__finally|_fortran|_import|_pascal|_stdcall|__thread|__try|asm|auto|bool|break|case|catch|cdecl|char|class|const|const_cast|continue|default|delete|do|double|dynamic_cast|else|enum|explicit|extern|false|float|for|friend|goto|if|inline|int|long|mutable|namespace|new|operator|pascal|private|protected|public|register|reinterpret_cast|return|short|signed|sizeof|static|static_cast|struct|switch|template|this|throw|true|try|typedef|typeid|typename|union|unsigned|using|virtual|void|volatile|wchar_t|while)\&gt;</code></td><td>6.98<BR>(0.0043s)</td><td>6.6<BR>(0.00406s)</td><td>6.73<BR>(0.00414s)</td><td>6.6<BR>(0.00406s)</td><td>NA</td><td>11.8<BR>(0.00727s)</td><td><font color="#008000">1<BR>(0.000615s)</font></td><td>NA</td><td>NA</td></tr>
+<tr><td><code>^[ 	]*#[ 	]*include[ 	]+(&quot;[^&quot;]+&quot;|&lt;[^&gt;]+&gt;)</code></td><td>6.32<BR>(0.000479s)</td><td>21.7<BR>(0.00164s)</td><td>2.13<BR>(0.000161s)</td><td>2.13<BR>(0.000161s)</td><td>NA</td><td>3.29<BR>(0.000249s)</td><td><font color="#008000">1<BR>(7.57e-05s)</font></td><td>1.97<BR>(0.000149s)</td><td>1.87<BR>(0.000142s)</td></tr>
+<tr><td><code>^[ 	]*#[ 	]*include[ 	]+(&quot;boost/[^&quot;]+&quot;|&lt;boost/[^&gt;]+&gt;)</code></td><td>6.32<BR>(0.000479s)</td><td>22.5<BR>(0.0017s)</td><td>2.13<BR>(0.000161s)</td><td>2.13<BR>(0.000161s)</td><td>NA</td><td>3.29<BR>(0.000249s)</td><td><font color="#008000">1<BR>(7.57e-05s)</font></td><td>1.94<BR>(0.000146s)</td><td>1.84<BR>(0.000139s)</td></tr>
+</table>
+</P>
+      <H3>
+         <H3>Comparison 4: HTML Document Search</H3>
       </H3>
-      <p>For each of the following regular expressions the time taken to find all 
-         occurrences of the expression within the html file <a href="../../libraries.htm">libs/libraries.htm</a>
-         was measured.&nbsp;</p>
-      <table border="1" cellspacing="1">
-         <tr>
-            <td><strong>Expression</strong></td>
-            <td><strong>Boost</strong></td>
-            <td><strong>Boost + C++ locale</strong></td>
-            <td><strong>POSIX</strong></td>
-            <td><strong>PCRE</strong></td>
-         </tr>
-         <tr>
-            <td><code>beman|john|dave</code></td>
-            <td><font color="#008000">1.03<br>
-                  (0.000367s)</font></td>
-            <td><font color="#008000">1<br>
-                  (0.000357s)</font></td>
-            <td>47.4<br>
-               (0.0169s)</td>
-            <td>1.16<br>
-               (0.000416s)</td>
-         </tr>
-         <tr>
-            <td><code>&lt;p&gt;.*?&lt;/p&gt;</code></td>
-            <td>1.25<br>
-               (0.000459s)</td>
-            <td><font color="#008000">1<br>
-                  (0.000367s)</font></td>
-            <td>NA</td>
-            <td><font color="#008000">1.03<br>
-                  (0.000376s)</font></td>
-         </tr>
-         <tr>
-            <td><code> &lt;a[^&gt;]+href=("[^"]*"|[^[:space:]]+)[^&gt;]*&gt;</code></td>
-            <td><font color="#008000">1<br>
-                  (0.000509s)</font></td>
-            <td><font color="#008000">1.02<br>
-                  (0.000518s)</font></td>
-            <td>305<br>
-               (0.155s)</td>
-            <td><font color="#008000">1.1<br>
-                  (0.000558s)</font></td>
-         </tr>
-         <tr>
-            <td><code> &lt;h[12345678][^&gt;]*&gt;.*?&lt;/h[12345678]&gt;</code></td>
-            <td><font color="#008000">1.04<br>
-                  (0.00025s)</font></td>
-            <td><font color="#008000">1<br>
-                  (0.00024s)</font></td>
-            <td>NA</td>
-            <td>1.16<br>
-               (0.000279s)</td>
-         </tr>
-         <tr>
-            <td><code> &lt;img[^&gt;]+src=("[^"]*"|[^[:space:]]+)[^&gt;]*&gt;</code></td>
-            <td>2.22<br>
-               (0.000489s)</td>
-            <td>1.69<br>
-               (0.000372s)</td>
-            <td>148<br>
-               (0.0326s)</td>
-            <td><font color="#008000">1<br>
-                  (0.00022s)</font></td>
-         </tr>
-         <tr>
-            <td><code> &lt;font[^&gt;]+face=("[^"]*"|[^[:space:]]+)[^&gt;]*&gt;.*?&lt;/font&gt;</code></td>
-            <td>1.71<br>
-               (0.000371s)</td>
-            <td>1.75<br>
-               (0.000381s)</td>
-            <td>NA</td>
-            <td><font color="#008000">1<br>
-                  (0.000218s)</font></td>
-         </tr>
-      </table>
-      <br>
-      <br>
-      <h3>Comparison 3: Simple Matches</h3>
-      <p>For each of the following regular expressions the time taken to match against 
+      <P>For each of the following regular expressions the time taken to find all 
+         occurrences of the expression within the html file <A href="../../libraries.htm">libs/libraries.htm</A>
+         was measured.&nbsp;</P>
+      <P><table border="1" cellspacing="1">
+<tr><td><strong>Expression</strong></td><td><strong>GRETA</strong></td><td><strong>GRETA<BR>(non-recursive mode)</strong></td><td><strong>Boost</strong></td><td><strong>Boost + C++ locale</strong></td><td><strong>POSIX</strong></td><td><strong>PCRE</strong></td><td><strong>PCRE JIT</strong></td><td><strong>Dynamic Xpressive</strong></td><td><strong>RE2</strong></td></tr>
+<tr><td><code>beman|john|dave</code></td><td>4.38<BR>(0.000791s)</td><td>8.76<BR>(0.00158s)</td><td>1.73<BR>(0.000313s)</td><td>1.73<BR>(0.000313s)</td><td>2.97<BR>(0.000537s)</td><td>2.19<BR>(0.000396s)</td><td><font color="#008000">1<BR>(0.000181s)</font></td><td>2.62<BR>(0.000474s)</td><td>1.49<BR>(0.000269s)</td></tr>
+<tr><td><code>&lt;a[^&gt;]+href=(&quot;[^&quot;]*&quot;|[^[:space:]]+)[^&gt;]*&gt;</code></td><td>2.45<BR>(0.000425s)</td><td>3.49<BR>(0.000605s)</td><td>3.44<BR>(0.000596s)</td><td>3.44<BR>(0.000596s)</td><td>51.4<BR>(0.00891s)</td><td>2.76<BR>(0.000479s)</td><td><font color="#008000">1<BR>(0.000173s)</font></td><td>4.51<BR>(0.000781s)</td><td>32.9<BR>(0.0057s)</td></tr>
+<tr><td><code>&lt;img[^&gt;]+src=(&quot;[^&quot;]*&quot;|[^[:space:]]+)[^&gt;]*&gt;</code></td><td>1.12<BR>(6.47e-05s)</td><td>1.14<BR>(6.59e-05s)</td><td>3.71<BR>(0.000215s)</td><td>3.66<BR>(0.000212s)</td><td>8.17<BR>(0.000474s)</td><td>3.07<BR>(0.000178s)</td><td><font color="#008000">1<BR>(5.8e-05s)</font></td><td>3.41<BR>(0.000198s)</td><td>2.02<BR>(0.000117s)</td></tr>
+<tr><td><code>&lt;p&gt;.*?&lt;/p&gt;</code></td><td>1.21<BR>(9.03e-05s)</td><td>1.26<BR>(9.4e-05s)</td><td>2.85<BR>(0.000212s)</td><td>2.85<BR>(0.000212s)</td><td>NA</td><td>2.52<BR>(0.000188s)</td><td><font color="#008000">1<BR>(7.45e-05s)</font></td><td>3.41<BR>(0.000254s)</td><td>6.82<BR>(0.000508s)</td></tr>
+<tr><td><code>&lt;h[12345678][^&gt;]*&gt;.*?&lt;/h[12345678]&gt;</code></td><td>1.73<BR>(0.000139s)</td><td>1.97<BR>(0.000159s)</td><td>2.76<BR>(0.000222s)</td><td>2.73<BR>(0.00022s)</td><td>NA</td><td>2.48<BR>(0.0002s)</td><td><font color="#008000">1<BR>(8.06e-05s)</font></td><td>4.85<BR>(0.000391s)</td><td>6.3<BR>(0.000508s)</td></tr>
+<tr><td><code>&lt;font[^&gt;]+face=(&quot;[^&quot;]*&quot;|[^[:space:]]+)[^&gt;]*&gt;.*?&lt;/font&gt;</code></td><td>1.27<BR>(7.2e-05s)</td><td>1.31<BR>(7.45e-05s)</td><td>3.74<BR>(0.000212s)</td><td>3.96<BR>(0.000225s)</td><td>NA</td><td>3.18<BR>(0.000181s)</td><td><font color="#008000">1<BR>(5.68e-05s)</font></td><td>3.1<BR>(0.000176s)</td><td><font color="#008000">1.02<BR>(5.8e-05s)</font></td></tr>
+</table>
+</P>
+      <H3>Comparison 3: Simple Matches</H3>
+      <p>
+         For each of the following regular expressions the time taken to match against 
          the text indicated was measured.&nbsp;</p>
-      <table border="1" cellspacing="1">
-         <tr>
-            <td><strong>Expression</strong></td>
-            <td><strong>Text</strong></td>
-            <td><strong>Boost</strong></td>
-            <td><strong>Boost + C++ locale</strong></td>
-            <td><strong>POSIX</strong></td>
-            <td><strong>PCRE</strong></td>
-         </tr>
-         <tr>
-            <td><code>abc</code></td>
-            <td>abc</td>
-            <td>1.36<br>
-               (2.15e-07s)</td>
-            <td>1.36<br>
-               (2.15e-07s)</td>
-            <td>2.76<br>
-               (4.34e-07s)</td>
-            <td><font color="#008000">1<br>
-                  (1.58e-07s)</font></td>
-         </tr>
-         <tr>
-            <td><code>^([0-9]+)(\-| |$)(.*)$</code></td>
-            <td>100- this is a line of ftp response which contains a message string</td>
-            <td>1.55<br>
-               (7.26e-07s)</td>
-            <td>1.51<br>
-               (7.07e-07s)</td>
-            <td>319<br>
-               (0.000149s)</td>
-            <td><font color="#008000">1<br>
-                  (4.67e-07s)</font></td>
-         </tr>
-         <tr>
-            <td><code>([[:digit:]]{4}[- ]){3}[[:digit:]]{3,4}</code></td>
-            <td>1234-5678-1234-456</td>
-            <td>1.96<br>
-               (9.54e-07s)</td>
-            <td>1.96<br>
-               (9.54e-07s)</td>
-            <td>44.5<br>
-               (2.17e-05s)</td>
-            <td><font color="#008000">1<br>
-                  (4.87e-07s)</font></td>
-         </tr>
-         <tr>
-            <td><code> ^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$</code></td>
-            <td>john@johnmaddock.co.uk</td>
-            <td>1.22<br>
-               (1.51e-06s)</td>
-            <td>1.23<br>
-               (1.53e-06s)</td>
-            <td>162<br>
-               (0.000201s)</td>
-            <td><font color="#008000">1<br>
-                  (1.24e-06s)</font></td>
-         </tr>
-         <tr>
-            <td><code> ^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$</code></td>
-            <td>foo12@foo.edu</td>
-            <td>1.28<br>
-               (1.47e-06s)</td>
-            <td>1.3<br>
-               (1.49e-06s)</td>
-            <td>104<br>
-               (0.00012s)</td>
-            <td><font color="#008000">1<br>
-                  (1.15e-06s)</font></td>
-         </tr>
-         <tr>
-            <td><code> ^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$</code></td>
-            <td>bob.smith@foo.tv</td>
-            <td>1.28<br>
-               (1.47e-06s)</td>
-            <td>1.3<br>
-               (1.49e-06s)</td>
-            <td>113<br>
-               (0.00013s)</td>
-            <td><font color="#008000">1<br>
-                  (1.15e-06s)</font></td>
-         </tr>
-         <tr>
-            <td><code>^[a-zA-Z]{1,2}[0-9][0-9A-Za-z]{0,1} {0,1}[0-9][A-Za-z]{2}$</code></td>
-            <td>EH10 2QQ</td>
-            <td>1.38<br>
-               (4.68e-07s)</td>
-            <td>1.41<br>
-               (4.77e-07s)</td>
-            <td>13.5<br>
-               (4.59e-06s)</td>
-            <td><font color="#008000">1<br>
-                  (3.39e-07s)</font></td>
-         </tr>
-         <tr>
-            <td><code>^[a-zA-Z]{1,2}[0-9][0-9A-Za-z]{0,1} {0,1}[0-9][A-Za-z]{2}$</code></td>
-            <td>G1 1AA</td>
-            <td>1.28<br>
-               (4.35e-07s)</td>
-            <td>1.25<br>
-               (4.25e-07s)</td>
-            <td>11.7<br>
-               (3.97e-06s)</td>
-            <td><font color="#008000">1<br>
-                  (3.39e-07s)</font></td>
-         </tr>
-         <tr>
-            <td><code>^[a-zA-Z]{1,2}[0-9][0-9A-Za-z]{0,1} {0,1}[0-9][A-Za-z]{2}$</code></td>
-            <td>SW1 1ZZ</td>
-            <td>1.32<br>
-               (4.53e-07s)</td>
-            <td>1.31<br>
-               (4.49e-07s)</td>
-            <td>12.2<br>
-               (4.2e-06s)</td>
-            <td><font color="#008000">1<br>
-                  (3.44e-07s)</font></td>
-         </tr>
-         <tr>
-            <td><code> ^[[:digit:]]{1,2}/[[:digit:]]{1,2}/[[:digit:]]{4}$</code></td>
-            <td>4/1/2001</td>
-            <td>1.16<br>
-               (3.82e-07s)</td>
-            <td>1.2<br>
-               (3.96e-07s)</td>
-            <td>13.9<br>
-               (4.59e-06s)</td>
-            <td><font color="#008000">1<br>
-                  (3.29e-07s)</font></td>
-         </tr>
-         <tr>
-            <td><code> ^[[:digit:]]{1,2}/[[:digit:]]{1,2}/[[:digit:]]{4}$</code></td>
-            <td>12/12/2001</td>
-            <td>1.38<br>
-               (4.49e-07s)</td>
-            <td>1.38<br>
-               (4.49e-07s)</td>
-            <td>16<br>
-               (5.2e-06s)</td>
-            <td><font color="#008000">1<br>
-                  (3.25e-07s)</font></td>
-         </tr>
-         <tr>
-            <td><code>^[-+]?[[:digit:]]*\.?[[:digit:]]*$</code></td>
-            <td>123</td>
-            <td>1.19<br>
-               (7.64e-07s)</td>
-            <td>1.16<br>
-               (7.45e-07s)</td>
-            <td>7.51<br>
-               (4.81e-06s)</td>
-            <td><font color="#008000">1<br>
-                  (6.4e-07s)</font></td>
-         </tr>
-         <tr>
-            <td><code>^[-+]?[[:digit:]]*\.?[[:digit:]]*$</code></td>
-            <td>+3.14159</td>
-            <td>1.32<br>
-               (8.97e-07s)</td>
-            <td>1.31<br>
-               (8.88e-07s)</td>
-            <td>14<br>
-               (9.48e-06s)</td>
-            <td><font color="#008000">1<br>
-                  (6.78e-07s)</font></td>
-         </tr>
-         <tr>
-            <td><code>^[-+]?[[:digit:]]*\.?[[:digit:]]*$</code></td>
-            <td>-3.14159</td>
-            <td>1.32<br>
-               (8.97e-07s)</td>
-            <td>1.31<br>
-               (8.88e-07s)</td>
-            <td>14<br>
-               (9.48e-06s)</td>
-            <td><font color="#008000">1<br>
-                  (6.78e-07s)</font></td>
-         </tr>
-      </table>
-      <br>
-      <br>
+      <P><table border="1" cellspacing="1">
+<tr><td><strong>Expression</strong></td><td><strong>Text</strong></td><td><strong>GRETA</strong></td><td><strong>GRETA<BR>(non-recursive mode)</strong></td><td><strong>Boost</strong></td><td><strong>Boost + C++ locale</strong></td><td><strong>POSIX</strong></td><td><strong>PCRE</strong></td><td><strong>PCRE JIT</strong></td><td><strong>Dynamic Xpressive</strong></td><td><strong>RE2</strong></td></tr>
+<tr><td><code>abc</code></td><td>abc</td><td>3.12<BR>(9.66e-08s)</td><td>4.62<BR>(1.43e-07s)</td><td>11.5<BR>(3.58e-07s)</td><td>11.7<BR>(3.62e-07s)</td><td>4.54<BR>(1.41e-07s)</td><td>5.08<BR>(1.57e-07s)</td><td><font color="#008000">1<BR>(3.1e-08s)</font></td><td>6.46<BR>(2e-07s)</td><td>3.77<BR>(1.17e-07s)</td></tr>
+<tr><td><code>^([0-9]+)(\-| |$)(.*)$</code></td><td>100- this is a line of ftp response which contains a message string</td><td>1.81<BR>(2.77e-07s)</td><td>3.38<BR>(5.15e-07s)</td><td>4.19<BR>(6.39e-07s)</td><td>4.25<BR>(6.48e-07s)</td><td>95<BR>(1.45e-05s)</td><td>2.41<BR>(3.67e-07s)</td><td><font color="#008000">1<BR>(1.53e-07s)</font></td><td>2.91<BR>(4.43e-07s)</td><td>3.5<BR>(5.34e-07s)</td></tr>
+<tr><td><code>([[:digit:]]{4}[- ]){3}[[:digit:]]{3,4}</code></td><td>1234-5678-1234-456</td><td>4.95<BR>(3.48e-07s)</td><td>8<BR>(5.63e-07s)</td><td>12.5<BR>(8.77e-07s)</td><td>13<BR>(9.16e-07s)</td><td>3.32<BR>(2.34e-07s)</td><td>5.36<BR>(3.77e-07s)</td><td><font color="#008000">1<BR>(7.03e-08s)</font></td><td>6.64<BR>(4.67e-07s)</td><td>4.54<BR>(3.19e-07s)</td></tr>
+<tr><td><code>^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$</code></td><td>john@johnmaddock.co.uk</td><td>5.64<BR>(1.18e-06s)</td><td>5.64<BR>(1.18e-06s)</td><td>7.18<BR>(1.51e-06s)</td><td>7.27<BR>(1.53e-06s)</td><td>30.2<BR>(6.33e-06s)</td><td>4.18<BR>(8.77e-07s)</td><td><font color="#008000">1<BR>(2.1e-07s)</font></td><td>5<BR>(1.05e-06s)</td><td>1.61<BR>(3.39e-07s)</td></tr>
+<tr><td><code>^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$</code></td><td>foo12@foo.edu</td><td>6.86<BR>(1.03e-06s)</td><td>6.86<BR>(1.03e-06s)</td><td>8.76<BR>(1.32e-06s)</td><td>9.27<BR>(1.39e-06s)</td><td>29.5<BR>(4.43e-06s)</td><td>4.89<BR>(7.34e-07s)</td><td><font color="#008000">1<BR>(1.5e-07s)</font></td><td>6.1<BR>(9.16e-07s)</td><td>2.03<BR>(3.05e-07s)</td></tr>
+<tr><td><code>^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$</code></td><td>bob.smith@foo.tv</td><td>7.1<BR>(1.05e-06s)</td><td>7.1<BR>(1.05e-06s)</td><td>8.9<BR>(1.32e-06s)</td><td>8.65<BR>(1.28e-06s)</td><td>31.5<BR>(4.65e-06s)</td><td>4.84<BR>(7.15e-07s)</td><td><font color="#008000">1<BR>(1.48e-07s)</font></td><td>6.32<BR>(9.35e-07s)</td><td>2.13<BR>(3.15e-07s)</td></tr>
+<tr><td><code>^[a-zA-Z]{1,2}[0-9][0-9A-Za-z]{0,1} {0,1}[0-9][A-Za-z]{2}$</code></td><td>EH10 2QQ</td><td>3.9<BR>(1.81e-07s)</td><td>5.95<BR>(2.77e-07s)</td><td>11.7<BR>(5.44e-07s)</td><td>10.9<BR>(5.05e-07s)</td><td>4.21<BR>(1.96e-07s)</td><td>4.62<BR>(2.15e-07s)</td><td><font color="#008000">1<BR>(4.65e-08s)</font></td><td>5.33<BR>(2.48e-07s)</td><td>6.05<BR>(2.81e-07s)</td></tr>
+<tr><td><code>^[a-zA-Z]{1,2}[0-9][0-9A-Za-z]{0,1} {0,1}[0-9][A-Za-z]{2}$</code></td><td>G1 1AA</td><td>3.54<BR>(1.65e-07s)</td><td>5.85<BR>(2.72e-07s)</td><td>10.7<BR>(4.96e-07s)</td><td>10.9<BR>(5.05e-07s)</td><td>3.9<BR>(1.81e-07s)</td><td>4.62<BR>(2.15e-07s)</td><td><font color="#008000">1<BR>(4.65e-08s)</font></td><td>5.54<BR>(2.57e-07s)</td><td>5.95<BR>(2.77e-07s)</td></tr>
+<tr><td><code>^[a-zA-Z]{1,2}[0-9][0-9A-Za-z]{0,1} {0,1}[0-9][A-Za-z]{2}$</code></td><td>SW1 1ZZ</td><td>3.85<BR>(1.81e-07s)</td><td>5.87<BR>(2.77e-07s)</td><td>10.5<BR>(4.96e-07s)</td><td>10.1<BR>(4.77e-07s)</td><td>3.95<BR>(1.86e-07s)</td><td>4.56<BR>(2.15e-07s)</td><td><font color="#008000">1<BR>(4.71e-08s)</font></td><td>5.27<BR>(2.48e-07s)</td><td>5.97<BR>(2.81e-07s)</td></tr>
+<tr><td><code>^[[:digit:]]{1,2}/[[:digit:]]{1,2}/[[:digit:]]{4}$</code></td><td>4/1/2001</td><td>3.32<BR>(1.74e-07s)</td><td>5.09<BR>(2.67e-07s)</td><td>8.73<BR>(4.58e-07s)</td><td>8.91<BR>(4.67e-07s)</td><td>3.68<BR>(1.93e-07s)</td><td>4.14<BR>(2.17e-07s)</td><td><font color="#008000">1<BR>(5.25e-08s)</font></td><td>4.64<BR>(2.43e-07s)</td><td>2.91<BR>(1.53e-07s)</td></tr>
+<tr><td><code>^[[:digit:]]{1,2}/[[:digit:]]{1,2}/[[:digit:]]{4}$</code></td><td>12/12/2001</td><td>3.27<BR>(1.72e-07s)</td><td>5<BR>(2.62e-07s)</td><td>9.27<BR>(4.86e-07s)</td><td>9.64<BR>(5.05e-07s)</td><td>3.91<BR>(2.05e-07s)</td><td>4.14<BR>(2.17e-07s)</td><td><font color="#008000">1<BR>(5.25e-08s)</font></td><td>5.36<BR>(2.81e-07s)</td><td>5.55<BR>(2.91e-07s)</td></tr>
+<tr><td><code>^[-+]?[[:digit:]]*\.?[[:digit:]]*$</code></td><td>123</td><td>3.03<BR>(1.34e-07s)</td><td>5.03<BR>(2.22e-07s)</td><td>10.3<BR>(4.53e-07s)</td><td>10.2<BR>(4.48e-07s)</td><td>8.11<BR>(3.58e-07s)</td><td>4.97<BR>(2.19e-07s)</td><td><font color="#008000">1<BR>(4.41e-08s)</font></td><td>5.3<BR>(2.34e-07s)</td><td>5.84<BR>(2.57e-07s)</td></tr>
+<tr><td><code>^[-+]?[[:digit:]]*\.?[[:digit:]]*$</code></td><td>+3.14159</td><td>3<BR>(1.57e-07s)</td><td>4.64<BR>(2.43e-07s)</td><td>10.5<BR>(5.53e-07s)</td><td>9.45<BR>(4.96e-07s)</td><td>10.2<BR>(5.34e-07s)</td><td>4.55<BR>(2.38e-07s)</td><td><font color="#008000">1<BR>(5.25e-08s)</font></td><td>4.64<BR>(2.43e-07s)</td><td>5.36<BR>(2.81e-07s)</td></tr>
+<tr><td><code>^[-+]?[[:digit:]]*\.?[[:digit:]]*$</code></td><td>-3.14159</td><td>2.97<BR>(1.57e-07s)</td><td>4.58<BR>(2.43e-07s)</td><td>10.4<BR>(5.53e-07s)</td><td>9.35<BR>(4.96e-07s)</td><td>10.1<BR>(5.34e-07s)</td><td>4.49<BR>(2.38e-07s)</td><td><font color="#008000">1<BR>(5.3e-08s)</font></td><td>4.94<BR>(2.62e-07s)</td><td>5.39<BR>(2.86e-07s)</td></tr>
+</table>
+</P>
       <hr>
-      <p><i>© Copyright John Maddock&nbsp;2003</i></p>
-      <P><I>Use, modification and distribution are subject to the Boost Software License, 
-            Version 1.0. (See accompanying file <A href="../../../LICENSE_1_0.txt">LICENSE_1_0.txt</A>
-            or copy at <A href="http://www.boost.org/LICENSE_1_0.txt">http://www.boost.org/LICENSE_1_0.txt</A>)</I></P>
+      <p><i>?? Copyright John Maddock&nbsp;2003</i></p>
+      <p><i>Use, modification and distribution are subject to the Boost Software License, 
+            Version 1.0. (See accompanying file <a href="../../../LICENSE_1_0.txt">LICENSE_1_0.txt</a>
+            or copy at <a href="http://www.boost.org/LICENSE_1_0.txt">http://www.boost.org/LICENSE_1_0.txt</a>)</i></p>
+
    </body>
 </html>
 

--- a/performance/Jamfile.v2
+++ b/performance/Jamfile.v2
@@ -3,12 +3,14 @@
 # (See accompanying file LICENSE_1_0.txt or copy at 
 # http://www.boost.org/LICENSE_1_0.txt.
 
-SOURCES = command_line main time_boost time_greta time_localised_boost time_pcre time_dynamic_xpressive time_posix time_safe_greta ;
+SOURCES = command_line main time_boost time_greta time_localised_boost time_pcre time_pcre_jit time_dynamic_xpressive time_posix time_safe_greta time_re2 ;
 
 local HS_REGEX_PATH = [ modules.peek : HS_REGEX_PATH ] ;
 local USE_POSIX = [ modules.peek : USE_POSIX ] ;
 local PCRE_PATH = [ modules.peek : PCRE_PATH ] ;
 local USE_PCRE = [ modules.peek : USE_PCRE ] ;
+local GRETA_PATH = [ modules.peek : GRETA_PATH ] ;
+local USE_RE2 = [ modules.peek : USE_RE2 ] ;
 
 if $(HS_REGEX_PATH)
 {
@@ -20,17 +22,32 @@ else if $(USE_POSIX)
    POSIX_OPTS = <define>BOOST_HAS_POSIX=1 ;
 }
 
-lib pcre : : <name>pcre ;
+lib pcre : : <name>pcre <search>/usr/local/lib ;
 
 if $(PCRE_PATH)
 {
+# currently pcre have more source files
    PCRE_SOURCES = $(PCRE_PATH)/chartables.c $(PCRE_PATH)/get.c $(PCRE_PATH)/pcre.c $(PCRE_PATH)/study.c ;
    PCRE_OPTS = <define>BOOST_HAS_PCRE=1 <include>$(PCRE_PATH) ;
 }
 else if $(USE_PCRE)
 {
-   PCRE_OPTS = <define>BOOST_HAS_PCRE=1 ;
+   PCRE_OPTS = <define>BOOST_HAS_PCRE=1 <define>BOOST_HAS_PCRE_JIT=1 ;
    PCRE_SOURCES = pcre ;
+}
+
+if $(GRETA_PATH)
+{
+   GRETA_SOURCES = $(GRETA_PATH)/regexpr2.cpp $(GRETA_PATH)/syntax2.cpp ;
+   GRETA_OPTS = <define>BOOST_HAS_GRETA=1 <include>$(GRETA_PATH) ;
+}
+
+lib re2 : : <name>re2 ;
+
+if $(USE_RE2)
+{
+   RE2_OPTS = <define>BOOST_HAS_RE2=1 ;
+   RE2_SOURCES = re2 ;
 }
 
 
@@ -38,13 +55,18 @@ exe regex_comparison :
     $(SOURCES).cpp
     $(HS_SOURCES)
     $(PCRE_SOURCES)
+    $(GRETA_SOURCES)
+    $(RE2_SOURCES)
     ../build//boost_regex
     ../../test/build//boost_prg_exec_monitor/<link>static
     : 
     <define>BOOST_REGEX_NO_LIB=1
     <define>BOOST_REGEX_STATIC_LINK=1
+    <define>BOOST_HAS_XPRESSIVE=1
     $(POSIX_OPTS)
     $(PCRE_OPTS)
+    $(GRETA_OPTS)
+    $(RE2_OPTS)
     ;
 
 

--- a/performance/command_line.cpp
+++ b/performance/command_line.cpp
@@ -33,7 +33,9 @@ bool time_greta = false;
 bool time_safe_greta = false;
 bool time_posix = false;
 bool time_pcre = false;
+bool time_pcre_jit = false;
 bool time_xpressive = false;
+bool time_re2 = false;
 bool time_std = false;
 
 bool test_matches = false;
@@ -55,7 +57,9 @@ double boost_total = 0;
 double locale_boost_total = 0;
 double posix_total = 0;
 double pcre_total = 0;
+double pcre_jit_total = 0;
 double xpressive_total = 0;
+double re2_total = 0;
 double std_total = 0;
 unsigned greta_test_count = 0;
 unsigned safe_greta_test_count = 0;
@@ -63,7 +67,9 @@ unsigned boost_test_count = 0;
 unsigned locale_boost_test_count = 0;
 unsigned posix_test_count = 0;
 unsigned pcre_test_count = 0;
+unsigned pcre_jit_test_count = 0;
 unsigned xpressive_test_count = 0;
+unsigned re2_test_count = 0;
 unsigned std_test_count = 0;
 
 int handle_argument(const std::string& what)
@@ -86,9 +92,17 @@ int handle_argument(const std::string& what)
    else if(what == "-pcre")
       time_pcre = true;
 #endif
+#ifdef BOOST_HAS_PCRE_JIT
+   else if(what == "-pcrejit")
+      time_pcre_jit = true;
+#endif
 #ifdef BOOST_HAS_XPRESSIVE
    else if(what == "-xpressive" || what == "-dxpr")
       time_xpressive = true;
+#endif
+#ifdef BOOST_HAS_RE2
+   else if(what == "-re2")
+      time_re2 = true;
 #endif
 #ifndef BOOST_NO_CXX11_HDR_REGEX
    else if(what == "-std")
@@ -108,8 +122,14 @@ int handle_argument(const std::string& what)
 #ifdef BOOST_HAS_PCRE
       time_pcre = true;
 #endif
+#ifdef BOOST_HAS_PCRE_JIT
+      time_pcre_jit = true;
+#endif
 #ifdef BOOST_HAS_XPRESSIVE
       time_xpressive = true;
+#endif
+#ifdef BOOST_HAS_RE2
+      time_re2 = true;
 #endif
 #ifndef BOOST_NO_CXX11_HDR_REGEX
       time_std = true;
@@ -174,8 +194,14 @@ int show_usage()
 #ifdef BOOST_HAS_PCRE
       "      -pcre  Apply tests to PCRE library\n"
 #endif
+#ifdef BOOST_HAS_PCRE_JIT
+      "      -pcrejit  Apply tests to PCRE library (int JIT mode)\n"
+#endif
 #ifdef BOOST_HAS_XPRESSIVE
       "      -dxpr  Apply tests to dynamic xpressive library\n"
+#endif
+#ifdef BOOST_HAS_RE2
+      "      -re2  Apply tests to google RE2 library\n"
 #endif
 #ifndef BOOST_NO_CXX11_HDR_REGEX
 	  "      -std  Apply tests to std::regex.\n"
@@ -283,9 +309,17 @@ void output_html_results(bool show_description, const std::string& tagname)
       if(time_pcre == true)
          os << "<td><strong>PCRE</strong></td>";
 #endif
+#ifdef BOOST_HAS_PCRE_JIT
+      if(time_pcre_jit == true)
+         os << "<td><strong>PCRE JIT</strong></td>";
+#endif
 #ifdef BOOST_HAS_XPRESSIVE
       if(time_xpressive == true)
          os << "<td><strong>Dynamic Xpressive</strong></td>";
+#endif
+#ifdef BOOST_HAS_RE2
+      if(time_re2 == true)
+         os << "<td><strong>RE2</strong></td>";
 #endif
 #ifndef BOOST_NO_CXX11_HDR_REGEX
       if(time_std == true)
@@ -362,6 +396,17 @@ void output_html_results(bool show_description, const std::string& tagname)
             }
          }
 #endif
+#if defined(BOOST_HAS_PCRE_JIT)
+         if(time_pcre_jit == true)
+         {
+            print_result(os, first->pcre_jit_time, first->factor);
+            if(first->pcre_jit_time > 0)
+            {
+               pcre_jit_total += first->pcre_jit_time / first->factor;
+               ++pcre_jit_test_count;
+            }
+         }
+#endif
 #if defined(BOOST_HAS_XPRESSIVE)
          if(time_xpressive == true)
          {
@@ -370,6 +415,17 @@ void output_html_results(bool show_description, const std::string& tagname)
             {
                xpressive_total += first->xpressive_time / first->factor;
                ++xpressive_test_count;
+            }
+         }
+#endif
+#if defined(BOOST_HAS_RE2)
+         if(time_re2 == true)
+         {
+            print_result(os, first->re2_time, first->factor);
+            if(first->re2_time > 0)
+            {
+               re2_total += first->re2_time / first->factor;
+               ++re2_test_count;
             }
          }
 #endif
@@ -450,10 +506,22 @@ std::string get_averages_table()
       os << "<td><strong>PCRE</strong></td>";
    }
 #endif
+#ifdef BOOST_HAS_PCRE_JIT
+   if(time_pcre_jit == true)
+   {
+      os << "<td><strong>PCRE JIT</strong></td>";
+   }
+#endif
 #ifdef BOOST_HAS_XPRESSIVE
    if(time_xpressive == true)
    {
       os << "<td><strong>Dynamic Xpressive</strong></td>";
+   }
+#endif
+#ifdef BOOST_HAS_RE2
+   if(time_re2 == true)
+   {
+      os << "<td><strong>google RE2</strong></td>";
    }
 #endif
 #ifndef BOOST_NO_CXX11_HDR_REGEX
@@ -474,23 +542,29 @@ std::string get_averages_table()
    if(time_safe_greta == true)
       os << "<td>" << (safe_greta_total / safe_greta_test_count) << "</td>\n";
 #endif
-#if defined(BOOST_HAS_POSIX)
-   if(time_boost == true)
-      os << "<td>" << (boost_total / boost_test_count) << "</td>\n";
-#endif
    if(time_boost == true)
       os << "<td>" << (boost_total / boost_test_count) << "</td>\n";
    if(time_localised_boost == true)
       os << "<td>" << (locale_boost_total / locale_boost_test_count) << "</td>\n";
+#if defined(BOOST_HAS_POSIX)
    if(time_posix == true)
       os << "<td>" << (posix_total / posix_test_count) << "</td>\n";
+#endif
 #if defined(BOOST_HAS_PCRE)
    if(time_pcre == true)
       os << "<td>" << (pcre_total / pcre_test_count) << "</td>\n";
 #endif
+#if defined(BOOST_HAS_PCRE_JIT)
+   if(time_pcre_jit == true)
+      os << "<td>" << (pcre_jit_total / pcre_jit_test_count) << "</td>\n";
+#endif
 #if defined(BOOST_HAS_XPRESSIVE)
    if(time_xpressive == true)
       os << "<td>" << (xpressive_total / xpressive_test_count) << "</td>\n";
+#endif
+#if defined(BOOST_HAS_RE2)
+   if(time_re2 == true)
+      os << "<td>" << (re2_total / re2_test_count) << "</td>\n";
 #endif
 #ifndef BOOST_NO_CXX11_HDR_REGEX
    if(time_std == true)

--- a/performance/input.html
+++ b/performance/input.html
@@ -60,7 +60,7 @@
          occurrences of the expression within the html file <A href="../../libraries.htm">libs/libraries.htm</A>
          was measured.&nbsp;</P>
       <P>%html_search%</P>
-      <H3>Comparison 3: Simple Matches</H3>
+      <H3>Comparison 5: Simple Matches</H3>
       <p>
          For each of the following regular expressions the time taken to match against 
          the text indicated was measured.&nbsp;</p>

--- a/performance/main.cpp
+++ b/performance/main.cpp
@@ -66,12 +66,28 @@ void test_match(const std::string& re, const std::string& text, const std::strin
       std::cout << "\tPCRE regex: " << time << "s\n";
    }
 #endif
+#ifdef BOOST_HAS_PCRE_JIT
+   if(time_pcre_jit == true)
+   {
+      time = pcrj::time_match(re, text, icase);
+      r.pcre_jit_time = time;
+      std::cout << "\tPCRE JIT regex: " << time << "s\n";
+   }
+#endif
 #ifdef BOOST_HAS_XPRESSIVE
    if(time_xpressive == true)
    {
       time = dxpr::time_match(re, text, icase);
       r.xpressive_time = time;
       std::cout << "\txpressive regex: " << time << "s\n";
+   }
+#endif
+#ifdef BOOST_HAS_RE2
+   if(time_re2 == true)
+   {
+      time = gre2::time_match(re, text, icase);
+      r.re2_time = time;
+      std::cout << "\tRE2 regex: " << time << "s\n";
    }
 #endif
 #ifndef BOOST_NO_CXX11_HDR_REGEX
@@ -135,12 +151,28 @@ void test_find_all(const std::string& re, const std::string& text, const std::st
       std::cout << "\tPCRE regex: " << time << "s\n";
    }
 #endif
+#ifdef BOOST_HAS_PCRE_JIT
+   if(time_pcre_jit == true)
+   {
+      time = pcrj::time_find_all(re, text, icase);
+      r.pcre_jit_time = time;
+      std::cout << "\tPCRE JIT regex: " << time << "s\n";
+   }
+#endif
 #ifdef BOOST_HAS_XPRESSIVE
    if(time_xpressive == true)
    {
       time = dxpr::time_find_all(re, text, icase);
       r.xpressive_time = time;
       std::cout << "\txpressive regex: " << time << "s\n";
+   }
+#endif
+#ifdef BOOST_HAS_RE2
+   if(time_re2 == true)
+   {
+      time = gre2::time_find_all(re, text, icase);
+      r.re2_time = time;
+      std::cout << "\tRE2 regex: " << time << "s\n";
    }
 #endif
 #ifndef BOOST_NO_CXX11_HDR_REGEX
@@ -226,10 +258,13 @@ int cpp_main(int argc, char * argv[])
       const char* boost_include_expression = "^[ \t]*#[ \t]*include[ \t]+(\"boost/[^\"]+\"|<boost/[^>]+>)";
 
 
+      bool time_posix_orig = time_posix;
+      time_posix = false;
       test_find_all(class_expression, file_contents);
       test_find_all(highlight_expression, file_contents);
       test_find_all(include_expression, file_contents);
       test_find_all(boost_include_expression, file_contents);
+      time_posix = time_posix_orig;
    }
    output_html_results(false, "%code_search%");
 
@@ -237,11 +272,15 @@ int cpp_main(int argc, char * argv[])
    {
       load_file(file_contents, "../../../libs/libraries.htm");
       test_find_all("beman|john|dave", file_contents, true);
-      test_find_all("<p>.*?</p>", file_contents, true);
       test_find_all("<a[^>]+href=(\"[^\"]*\"|[^[:space:]]+)[^>]*>", file_contents, true);
-      test_find_all("<h[12345678][^>]*>.*?</h[12345678]>", file_contents, true);
       test_find_all("<img[^>]+src=(\"[^\"]*\"|[^[:space:]]+)[^>]*>", file_contents, true);
+      bool time_posix_orig = time_posix;
+      time_posix = false;
+      // POSIX-Extended unspport Non greedy repeats 
+      test_find_all("<p>.*?</p>", file_contents, true); 
+      test_find_all("<h[12345678][^>]*>.*?</h[12345678]>", file_contents, true);
       test_find_all("<font[^>]+face=(\"[^\"]*\"|[^[:space:]]+)[^>]*>.*?</font>", file_contents, true);
+      time_posix = time_posix_orig;
    }
    output_html_results(false, "%html_search%");
 
@@ -252,7 +291,10 @@ int cpp_main(int argc, char * argv[])
       test_find_all("Twain", file_contents);
       test_find_all("Huck[[:alpha:]]+", file_contents);
       test_find_all("[[:alpha:]]+ing", file_contents);
+      bool time_posix_orig = time_posix;
+      time_posix = false;
       test_find_all("^[^\n]*?Twain", file_contents);
+      time_posix = time_posix_orig;
       test_find_all("Tom|Sawyer|Huckleberry|Finn", file_contents);
       test_find_all("(Tom|Sawyer|Huckleberry|Finn).{0,30}river|river.{0,30}(Tom|Sawyer|Huckleberry|Finn)", file_contents);
    }
@@ -260,16 +302,17 @@ int cpp_main(int argc, char * argv[])
 
    if(test_long_twain)
    {
-      load_file(file_contents, "mtent13.txt");
+      load_file(file_contents, "mtent12.txt");
 
       test_find_all("Twain", file_contents);
       test_find_all("Huck[[:alpha:]]+", file_contents);
       test_find_all("[[:alpha:]]+ing", file_contents);
-      test_find_all("^[^\n]*?Twain", file_contents);
-      test_find_all("Tom|Sawyer|Huckleberry|Finn", file_contents);
+      bool time_posix_orig = time_posix;
       time_posix = false;
+      test_find_all("^[^\n]*?Twain", file_contents); // POSIX-Extended: the escape character is not "special" inside a character class declaration
+      time_posix = time_posix_orig;
+      test_find_all("Tom|Sawyer|Huckleberry|Finn", file_contents);
       test_find_all("(Tom|Sawyer|Huckleberry|Finn).{0,30}river|river.{0,30}(Tom|Sawyer|Huckleberry|Finn)", file_contents);
-      time_posix = true;
    }   
    output_html_results(false, "%long_twain_search%");
 

--- a/performance/regex_comparison.hpp
+++ b/performance/regex_comparison.hpp
@@ -26,7 +26,9 @@ extern bool time_greta;
 extern bool time_safe_greta;
 extern bool time_posix;
 extern bool time_pcre;
+extern bool time_pcre_jit;
 extern bool time_xpressive;
+extern bool time_re2;
 extern bool time_std;
 
 extern bool test_matches;
@@ -55,7 +57,9 @@ struct results
    double safe_greta_time;
    double posix_time;
    double pcre_time;
+   double pcre_jit_time;
    double xpressive_time;
+   double re2_time;
    double std_time;
    double factor;
    std::string expression;
@@ -67,7 +71,9 @@ struct results
         safe_greta_time(-1),
         posix_time(-1),
         pcre_time(-1),
+        pcre_jit_time(-1),
         xpressive_time(-1),
+        re2_time(-1),
 		std_time(-1),
         factor((std::numeric_limits<double>::max)()),
         expression(ex), 
@@ -87,8 +93,12 @@ struct results
          factor = posix_time;
       if((pcre_time >= 0) && (pcre_time < factor))
          factor = pcre_time;
+      if((pcre_jit_time >= 0) && (pcre_jit_time < factor))
+         factor = pcre_jit_time;
       if((xpressive_time >= 0) && (xpressive_time < factor))
          factor = xpressive_time;
+      if((re2_time >= 0) && (re2_time < factor))
+         factor = re2_time;
       if((std_time >= 0) && (std_time < factor))
          factor = std_time;
    }
@@ -111,6 +121,12 @@ double time_find_all(const std::string& re, const std::string& text, bool icase)
 }
 namespace pcr {
 // pcre tests:
+double time_match(const std::string& re, const std::string& text, bool icase);
+double time_find_all(const std::string& re, const std::string& text, bool icase);
+
+}
+namespace pcrj {
+// pcre jit tests:
 double time_match(const std::string& re, const std::string& text, bool icase);
 double time_find_all(const std::string& re, const std::string& text, bool icase);
 
@@ -138,8 +154,13 @@ namespace dxpr {
 double time_match(const std::string& re, const std::string& text, bool icase);
 double time_find_all(const std::string& re, const std::string& text, bool icase);
 }
+namespace gre2 {
+// re2 tests:
+double time_match(const std::string& re, const std::string& text, bool icase);
+double time_find_all(const std::string& re, const std::string& text, bool icase);
+}
 namespace stdr {
-// xpressive tests:
+// C11 tests:
 double time_match(const std::string& re, const std::string& text, bool icase);
 double time_find_all(const std::string& re, const std::string& text, bool icase);
 }


### PR DESCRIPTION
* Add Google RE2 and pcre jit mode performance test .
* Disable some test items that cannot obtain exptected result by posix library.  Posix extended lack non greedy repeats and escape character, eg "\n" .
* Updated gcc-performance.html for CentOS 6.4.