### PR TITLE
Prevent unnecessary string scanning.

### DIFF
--- a/include/boost/regex/v4/regex_workaround.hpp
+++ b/include/boost/regex/v4/regex_workaround.hpp
@@ -46,12 +46,6 @@
 #   include <locale>
 #endif
 
-#if defined(BOOST_NO_STDC_NAMESPACE)
-namespace std{
-   using ::sprintf; using ::strcpy; using ::strcat; using ::strlen;
-}
-#endif
-
 namespace boost{ namespace re_detail{
 #ifdef BOOST_NO_STD_DISTANCE
 template <class T>
@@ -83,6 +77,7 @@ namespace std{
    using ::abs;
    using ::memset;
    using ::memcpy;
+   using ::strlen;
 }
 
 #endif
@@ -196,9 +191,10 @@ namespace boost{ namespace re_detail{
       const char *strSource 
    )
    {
-      if(std::strlen(strSource)+1 > sizeInBytes)
+      std::size_t lenSource = std::strlen(strSource) + 1;
+      if(lenSource > sizeInBytes)
          return 1;
-      std::strcpy(strDestination, strSource);
+      std::memcpy(strDestination, strSource, lenSource);
       return 0;
    }
    inline std::size_t strcat_s(
@@ -207,9 +203,11 @@ namespace boost{ namespace re_detail{
       const char *strSource 
    )
    {
-      if(std::strlen(strSource) + std::strlen(strDestination) + 1 > sizeInBytes)
+      std::size_t lenSource = std::strlen(strSource) + 1;
+      std::size_t lenDestination = std::strlen(strDestination);
+      if(lenSource + lenDestination > sizeInBytes)
          return 1;
-      std::strcat(strDestination, strSource);
+      std::memcpy(strDestination + lenDestination, strSource, lenSource);
       return 0;
    }
 


### PR DESCRIPTION
The internal strcat_s() function already calls strlen() on the
source/destination strings to check for overflows. Instead of calling
into strcat() and scanning over the string again, we can simply call
memcpy() to copy the text over to the right place.

Apply the same optimization to strcpy_s(). memcpy() is almost always
faster than strcpy(), for the reason that testing against a counter is
faster than searching for a null byte in the input sequence.

This change allows the code to build with Nuxi CloudABI's C library[1].
This C library does not provide implementations for strcpy(), strcat()
and strncat(), as in addition to being potentially insecure, the
observation is that if you want to use these securely, you can almost
always use memcpy() instead.

[1] cloudlibc: https://github.com/NuxiNL/cloudlibc