### PR TITLE
universal-windows: Port to winrt

### DIFF
--- a/include/boost/regex/config.hpp
+++ b/include/boost/regex/config.hpp
@@ -278,8 +278,13 @@
 #  define BOOST_REGEX_USE_C_LOCALE
 #endif
 
+#if defined(WINAPI_FAMILY) && \
+    ( WINAPI_FAMILY == WINAPI_FAMILY_APP || WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP )
+#  define BOOST_REGEX_NO_WIN32_LOCALE
+#endif
+
 /* Win32 defaults to native Win32 locale: */
-#if defined(_WIN32) && !defined(BOOST_REGEX_USE_WIN32_LOCALE) && !defined(BOOST_REGEX_USE_C_LOCALE) && !defined(BOOST_REGEX_USE_CPP_LOCALE) && !defined(BOOST_REGEX_NO_W32)
+#if defined(_WIN32) && !defined(BOOST_REGEX_USE_WIN32_LOCALE) && !defined(BOOST_REGEX_USE_C_LOCALE) && !defined(BOOST_REGEX_USE_CPP_LOCALE) && !defined(BOOST_REGEX_NO_W32) && !defined(BOOST_REGEX_NO_WIN32_LOCALE)
 #  define BOOST_REGEX_USE_WIN32_LOCALE
 #endif
 /* otherwise use C++ locale if supported: */

--- a/include/boost/regex/config.hpp
+++ b/include/boost/regex/config.hpp
@@ -177,10 +177,20 @@
  * with MSVC and the /Zc:wchar_t option we place some extra unsigned short versions
  * of the non-inline functions in the library, so that users can still link to the lib,
  * irrespective of whether their own code is built with /Zc:wchar_t.
- * Note that this does NOT WORK with VC10 when the C++ locale is in effect as
+ * Note that this does NOT WORK with VC10 and VC14 when the C++ locale is in effect as
  * the locale's <unsigned short> facets simply do not compile in that case.
+ * As we default to the C++ locale when compiling for the windows runtime we
+ * skip in this case aswell.
  */
-#if defined(__cplusplus) && (defined(BOOST_MSVC) || defined(__ICL)) && !defined(BOOST_NO_INTRINSIC_WCHAR_T) && defined(BOOST_WINDOWS) && !defined(__SGI_STL_PORT) && !defined(_STLPORT_VERSION) && !defined(BOOST_RWSTD_VER) && ((_MSC_VER < 1600) || !defined(BOOST_REGEX_USE_CPP_LOCALE))
+#if defined(__cplusplus) && \
+      (defined(BOOST_MSVC) || defined(__ICL)) && \
+      !defined(BOOST_NO_INTRINSIC_WCHAR_T) && \
+      defined(BOOST_WINDOWS) && \
+      !defined(__SGI_STL_PORT) && \
+      !defined(_STLPORT_VERSION) && \
+      !defined(BOOST_RWSTD_VER) && \
+      ((_MSC_VER < 1600) || !defined(BOOST_REGEX_USE_CPP_LOCALE)) && \
+      !BOOST_PLAT_WINDOWS_RUNTIME
 #  define BOOST_REGEX_HAS_OTHER_WCHAR_T
 #  ifdef BOOST_MSVC
 #     pragma warning(push)

--- a/include/boost/regex/config.hpp
+++ b/include/boost/regex/config.hpp
@@ -42,6 +42,7 @@
 #  include BOOST_REGEX_USER_CONFIG
 
 #  include <boost/config.hpp>
+#  include <boost/predef.h>
 
 #else
    /*
@@ -288,8 +289,7 @@
 #  define BOOST_REGEX_USE_C_LOCALE
 #endif
 
-#if defined(WINAPI_FAMILY) && \
-    ( WINAPI_FAMILY == WINAPI_FAMILY_APP || WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP )
+#if BOOST_PLAT_WINDOWS_RUNTIME
 #  define BOOST_REGEX_NO_WIN32_LOCALE
 #endif
 

--- a/include/boost/regex/v4/w32_regex_traits.hpp
+++ b/include/boost/regex/v4/w32_regex_traits.hpp
@@ -19,6 +19,8 @@
 #ifndef BOOST_W32_REGEX_TRAITS_HPP_INCLUDED
 #define BOOST_W32_REGEX_TRAITS_HPP_INCLUDED
 
+#ifndef BOOST_REGEX_NO_WIN32_LOCALE
+
 #ifndef BOOST_RE_PAT_EXCEPT_HPP
 #include <boost/regex/pattern_except.hpp>
 #endif
@@ -735,5 +737,7 @@ static_mutex& w32_regex_traits<charT>::get_mutex_inst()
 #ifdef BOOST_MSVC
 #pragma warning(pop)
 #endif
+
+#endif // BOOST_REGEX_NO_WIN32_LOCALE
 
 #endif

--- a/src/fileiter.cpp
+++ b/src/fileiter.cpp
@@ -23,6 +23,7 @@
 #include <climits>
 #include <stdexcept>
 #include <string>
+#include <boost/predef.h>
 #include <boost/throw_exception.hpp>
 #include <boost/regex/v4/fileiter.hpp>
 #include <boost/regex/v4/regex_workaround.hpp>
@@ -396,13 +397,9 @@ inline _fi_find_handle find_first_file(const char* wild,  _fi_find_data& data)
    if (::MultiByteToWideChar(CP_ACP, 0,  wild, wild_size,  wide_wild, wild_size + 1) == 0)
       return _fi_invalid_handle;
 
-# if BOOST_PLAT_WINDOWS_RUNTIME
    return FindFirstFileExW(wide_wild, FindExInfoStandard, &data, FindExSearchNameMatch, NULL, 0);
-# else
-   return FindFirstFileW(wide_wild, &data);
-# endif
 #else
-   return FindFirstFileA(wild, &data);
+   return FindFirstFileExA(wild, FindExInfoStandard, &data, FindExSearchNameMatch, NULL, 0);
 #endif
 }
 

--- a/src/w32_regex_traits.cpp
+++ b/src/w32_regex_traits.cpp
@@ -19,7 +19,7 @@
 #define BOOST_REGEX_SOURCE
 #include <boost/regex/config.hpp>
 
-#if defined(_WIN32) && !defined(BOOST_REGEX_NO_W32)
+#if defined(_WIN32) && !defined(BOOST_REGEX_NO_W32) && !defined(BOOST_REGEX_NO_WIN32_LOCALE)
 #include <boost/regex/regex_traits.hpp>
 #include <boost/regex/pattern_except.hpp>
 


### PR DESCRIPTION
This makes fileiter.cpp compile when targeting universal windows (b2 windows-api=store) I still need to port w32_regex_traits for the entire library to build so this PR can wait but I thought I could push it as soon as possible to gather feedback.

UPDATE: everything compiles. w32_regex_traits has been ifdeffed-out though (see commit-message)