### PR TITLE
Universal windows

### DIFF
--- a/include/boost/regex/config.hpp
+++ b/include/boost/regex/config.hpp
@@ -298,10 +298,16 @@
 /* use C++ locale when targeting windows store */
 #if BOOST_PLAT_WINDOWS_RUNTIME
 #  define BOOST_REGEX_USE_CPP_LOCALE
+#  define BOOST_REGEX_NO_WIN32_LOCALE
 #endif
 
 /* Win32 defaults to native Win32 locale: */
-#if defined(_WIN32) && !defined(BOOST_REGEX_USE_WIN32_LOCALE) && !defined(BOOST_REGEX_USE_C_LOCALE) && !defined(BOOST_REGEX_USE_CPP_LOCALE) && !defined(BOOST_REGEX_NO_W32)
+#if defined(_WIN32) && \
+    !defined(BOOST_REGEX_USE_WIN32_LOCALE) && \
+    !defined(BOOST_REGEX_USE_C_LOCALE) && \
+    !defined(BOOST_REGEX_USE_CPP_LOCALE) && \
+    !defined(BOOST_REGEX_NO_W32) && \
+    !defined(BOOST_REGEX_NO_WIN32_LOCALE)
 #  define BOOST_REGEX_USE_WIN32_LOCALE
 #endif
 /* otherwise use C++ locale if supported: */

--- a/include/boost/regex/config.hpp
+++ b/include/boost/regex/config.hpp
@@ -289,6 +289,11 @@
 #  define BOOST_REGEX_USE_C_LOCALE
 #endif
 
+/* use C++ locale when targeting windows store */
+#if BOOST_PLAT_WINDOWS_RUNTIME
+#  define BOOST_REGEX_USE_CPP_LOCALE
+#endif
+
 /* Win32 defaults to native Win32 locale: */
 #if defined(_WIN32) && !defined(BOOST_REGEX_USE_WIN32_LOCALE) && !defined(BOOST_REGEX_USE_C_LOCALE) && !defined(BOOST_REGEX_USE_CPP_LOCALE) && !defined(BOOST_REGEX_NO_W32)
 #  define BOOST_REGEX_USE_WIN32_LOCALE

--- a/include/boost/regex/config.hpp
+++ b/include/boost/regex/config.hpp
@@ -42,6 +42,7 @@
 #  include BOOST_REGEX_USER_CONFIG
 
 #  include <boost/config.hpp>
+#  include <boost/predef.h>
 
 #else
    /*

--- a/include/boost/regex/config.hpp
+++ b/include/boost/regex/config.hpp
@@ -148,8 +148,14 @@
 
 /* disable our own file-iterators and mapfiles if we can't
  * support them: */
-#if !defined(BOOST_HAS_DIRENT_H) && !(defined(_WIN32) && !defined(BOOST_REGEX_NO_W32))
-#  define BOOST_REGEX_NO_FILEITER
+#if defined(_WIN32)
+#  if defined(BOOST_REGEX_NO_W32) || BOOST_PLAT_WINDOWS_STORE
+#    define BOOST_REGEX_NO_FILEITER
+#  endif
+#else // defined(_WIN32)
+#  if !defined(BOOST_HAS_DIRENT_H)
+#    define BOOST_REGEX_NO_FILEITER
+#  endif
 #endif
 
 /* backwards compatibitity: */

--- a/include/boost/regex/config.hpp
+++ b/include/boost/regex/config.hpp
@@ -178,10 +178,20 @@
  * with MSVC and the /Zc:wchar_t option we place some extra unsigned short versions
  * of the non-inline functions in the library, so that users can still link to the lib,
  * irrespective of whether their own code is built with /Zc:wchar_t.
- * Note that this does NOT WORK with VC10 when the C++ locale is in effect as
+ * Note that this does NOT WORK with VC10 and VC14 when the C++ locale is in effect as
  * the locale's <unsigned short> facets simply do not compile in that case.
+ * As we default to the C++ locale when compiling for the windows runtime we
+ * skip in this case aswell.
  */
-#if defined(__cplusplus) && (defined(BOOST_MSVC) || defined(__ICL)) && !defined(BOOST_NO_INTRINSIC_WCHAR_T) && defined(BOOST_WINDOWS) && !defined(__SGI_STL_PORT) && !defined(_STLPORT_VERSION) && !defined(BOOST_RWSTD_VER) && ((_MSC_VER < 1600) || !defined(BOOST_REGEX_USE_CPP_LOCALE))
+#if defined(__cplusplus) && \
+      (defined(BOOST_MSVC) || defined(__ICL)) && \
+      !defined(BOOST_NO_INTRINSIC_WCHAR_T) && \
+      defined(BOOST_WINDOWS) && \
+      !defined(__SGI_STL_PORT) && \
+      !defined(_STLPORT_VERSION) && \
+      !defined(BOOST_RWSTD_VER) && \
+      ((_MSC_VER < 1600) || !defined(BOOST_REGEX_USE_CPP_LOCALE)) && \
+      !BOOST_PLAT_WINDOWS_RUNTIME
 #  define BOOST_REGEX_HAS_OTHER_WCHAR_T
 #  ifdef BOOST_MSVC
 #     pragma warning(push)

--- a/include/boost/regex/v4/w32_regex_traits.hpp
+++ b/include/boost/regex/v4/w32_regex_traits.hpp
@@ -19,6 +19,8 @@
 #ifndef BOOST_W32_REGEX_TRAITS_HPP_INCLUDED
 #define BOOST_W32_REGEX_TRAITS_HPP_INCLUDED
 
+#ifndef BOOST_REGEX_NO_WIN32_LOCALE
+
 #ifndef BOOST_RE_PAT_EXCEPT_HPP
 #include <boost/regex/pattern_except.hpp>
 #endif
@@ -735,5 +737,7 @@ static_mutex& w32_regex_traits<charT>::get_mutex_inst()
 #ifdef BOOST_MSVC
 #pragma warning(pop)
 #endif
+
+#endif // BOOST_REGEX_NO_WIN32_LOCALE
 
 #endif

--- a/src/w32_regex_traits.cpp
+++ b/src/w32_regex_traits.cpp
@@ -19,7 +19,7 @@
 #define BOOST_REGEX_SOURCE
 #include <boost/regex/config.hpp>
 
-#if defined(_WIN32) && !defined(BOOST_REGEX_NO_W32)
+#if defined(_WIN32) && !defined(BOOST_REGEX_NO_W32) && !defined(BOOST_REGEX_NO_WIN32_LOCALE)
 #include <boost/regex/regex_traits.hpp>
 #include <boost/regex/pattern_except.hpp>
 


### PR DESCRIPTION
Add support for universal windows (aka winrt, windows store).

Instead of just disabling all Win32 "extensions" by just defining BOOST_REGEX_NO_W32 I opted to disable *just* the parts which need disabling. This way BOOST_REGEX_HAS_MS_STACK_GUARD will still be defined when targeting uwp.

w32_regex_traits has been disabled because it uses LCID which has been deprecated since Vista and LCID no longer available in windows store (somewhat true).

However an interesting fact is that the c++ locale actually works with the locale-names supported since Vista as can be seen from this dirty little test program:

https://gist.github.com/mauve/fd5feb08333bda97f06b



