### PR TITLE
Check if f is valid before dereference

### DIFF
--- a/include/boost/regex/v4/fileiter.hpp
+++ b/include/boost/regex/v4/fileiter.hpp
@@ -225,12 +225,11 @@ public:
    mapfile_iterator() { node = 0; file = 0; offset = 0; }
    mapfile_iterator(const mapfile* f, long arg_position)
    {
+      BOOST_ASSERT(f); 
       file = f;
-      if(f)
-         node = f->_first + arg_position / mapfile::buf_size;
+      node = f->_first + arg_position / mapfile::buf_size;
       offset = arg_position % mapfile::buf_size;
-      if(file)
-         file->lock(node);
+      file->lock(node);
    }
    mapfile_iterator(const mapfile_iterator& i)
    {

--- a/include/boost/regex/v4/fileiter.hpp
+++ b/include/boost/regex/v4/fileiter.hpp
@@ -226,7 +226,8 @@ public:
    mapfile_iterator(const mapfile* f, long arg_position)
    {
       file = f;
-      node = f->_first + arg_position / mapfile::buf_size;
+      if(f)
+         node = f->_first + arg_position / mapfile::buf_size;
       offset = arg_position % mapfile::buf_size;
       if(file)
          file->lock(node);


### PR DESCRIPTION
file = f at line no 228.
file is checked against NULL at 232, but f is not checked. Adding null check.