### PR TITLE
avoid duplicate check of markid.

### DIFF
--- a/include/boost/regex/v4/basic_regex_parser.hpp
+++ b/include/boost/regex/v4/basic_regex_parser.hpp
@@ -2650,7 +2650,7 @@ option_group_jump:
       //
       // allow backrefs to this mark:
       //
-      if((markid > 0) && (markid < (int)(sizeof(unsigned) * CHAR_BIT)))
+      if(markid < (int)(sizeof(unsigned) * CHAR_BIT))
          this->m_backrefs |= 1u << (markid - 1);
    }
    return true;


### PR DESCRIPTION
Markid is already checked to be >0.