### PR TITLE
Made the mem_cache_block lockfree

### DIFF
--- a/include/boost/regex/v4/mem_block_cache.hpp
+++ b/include/boost/regex/v4/mem_block_cache.hpp
@@ -19,18 +19,12 @@
 #define BOOST_REGEX_V4_MEM_BLOCK_CACHE_HPP
 
 #include <new>
-#include <boost/atomic/atomic.hpp>
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_PREFIX
 #endif
 
-#ifdef BOOST_NO_CXX11_HDR_ATOMIC
-  #if BOOST_ATOMIC_POINTER_LOCK_FREE == 2
-    #define BOOST_REGEX_MEM_BLOCK_CACHE_LOCK_FREE
-    #define BOOST_REGEX_ATOMIC_POINTER boost::atomic
-  #endif
-#else // BOOST_NOCXX11_HDR_ATOMIC not defined
+#ifndef BOOST_NO_CXX11_HDR_ATOMIC
   #include <atomic>
   #if ATOMIC_POINTER_LOCK_FREE == 2
     #define BOOST_REGEX_MEM_BLOCK_CACHE_LOCK_FREE
@@ -44,14 +38,8 @@ namespace BOOST_REGEX_DETAIL_NS{
 #ifdef BOOST_REGEX_MEM_BLOCK_CACHE_LOCK_FREE /* lock free implementation */
 struct mem_block_cache
 {
-   BOOST_REGEX_ATOMIC_POINTER<void*> cache[BOOST_REGEX_MAX_CACHE_BLOCKS];
+  std::atomic<void*> cache[BOOST_REGEX_MAX_CACHE_BLOCKS];
 
-   mem_block_cache() {
-     for (size_t i = 0;i < BOOST_REGEX_MAX_CACHE_BLOCKS; ++i) {
-       cache[i].store(NULL);
-     }
-
-   }
    ~mem_block_cache()
    {
      for (size_t i = 0;i < BOOST_REGEX_MAX_CACHE_BLOCKS; ++i) {
@@ -80,7 +68,6 @@ struct mem_block_cache
    }
 };
 
-#undef BOOST_REGEX_ATOMIC_POINTER
 
 #else /* lock-based implementation */
 

--- a/include/boost/regex/v4/mem_block_cache.hpp
+++ b/include/boost/regex/v4/mem_block_cache.hpp
@@ -25,12 +25,26 @@
 #  include BOOST_ABI_PREFIX
 #endif
 
+#ifdef BOOST_NO_CXX11_HDR_ATOMIC
+  #if BOOST_ATOMIC_POINTER_LOCK_FREE == 2
+    #define BOOST_REGEX_MEM_BLOCK_CACHE_LOCK_FREE
+    #define BOOST_REGEX_ATOMIC_POINTER boost::atomic
+  #endif
+#else // BOOST_NOCXX11_HDR_ATOMIC not defined
+  #include <atomic>
+  #if ATOMIC_POINTER_LOCK_FREE == 2
+    #define BOOST_REGEX_MEM_BLOCK_CACHE_LOCK_FREE
+    #define BOOST_REGEX_ATOMIC_POINTER std::atomic
+  #endif
+#endif
+
 namespace boost{
 namespace BOOST_REGEX_DETAIL_NS{
 
+#ifdef BOOST_REGEX_MEM_BLOCK_CACHE_LOCK_FREE /* lock free implementation */
 struct mem_block_cache
 {
-   boost::atomic<void*> cache[BOOST_REGEX_MAX_CACHE_BLOCKS];
+   BOOST_REGEX_ATOMIC_POINTER<void*> cache[BOOST_REGEX_MAX_CACHE_BLOCKS];
 
    mem_block_cache() {
      for (size_t i = 0;i < BOOST_REGEX_MAX_CACHE_BLOCKS; ++i) {
@@ -65,6 +79,68 @@ struct mem_block_cache
      ::operator delete(ptr);
    }
 };
+
+#undef BOOST_REGEX_ATOMIC_POINTER
+
+#else /* lock-based implementation */
+
+
+struct mem_block_node
+{
+   mem_block_node* next;
+};
+
+struct mem_block_cache
+{
+   // this member has to be statically initialsed:
+   mem_block_node* next;
+   unsigned cached_blocks;
+#ifdef BOOST_HAS_THREADS
+   boost::static_mutex mut;
+#endif
+
+   ~mem_block_cache()
+   {
+      while(next)
+      {
+         mem_block_node* old = next;
+         next = next->next;
+         ::operator delete(old);
+      }
+   }
+   void* get()
+   {
+#ifdef BOOST_HAS_THREADS
+      boost::static_mutex::scoped_lock g(mut);
+#endif
+     if(next)
+      {
+         mem_block_node* result = next;
+         next = next->next;
+         --cached_blocks;
+         return result;
+      }
+      return ::operator new(BOOST_REGEX_BLOCKSIZE);
+   }
+   void put(void* p)
+   {
+#ifdef BOOST_HAS_THREADS
+      boost::static_mutex::scoped_lock g(mut);
+#endif
+      if(cached_blocks >= BOOST_REGEX_MAX_CACHE_BLOCKS)
+      {
+         ::operator delete(p);
+      }
+      else
+      {
+         mem_block_node* old = static_cast<mem_block_node*>(p);
+         old->next = next;
+         next = old;
+         ++cached_blocks;
+      }
+   }
+};
+#endif
 
 extern mem_block_cache block_cache;
 

--- a/include/boost/regex/v4/mem_block_cache.hpp
+++ b/include/boost/regex/v4/mem_block_cache.hpp
@@ -19,6 +19,9 @@
 #define BOOST_REGEX_V4_MEM_BLOCK_CACHE_HPP
 
 #include <new>
+#ifdef BOOST_HAS_THREADS
+#include <boost/regex/pending/static_mutex.hpp>
+#endif
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_PREFIX

--- a/src/regex.cpp
+++ b/src/regex.cpp
@@ -192,7 +192,7 @@ BOOST_REGEX_DECL void BOOST_REGEX_CALL put_mem_block(void* p)
 #else
 
 #if defined(BOOST_REGEX_MEM_BLOCK_CACHE_LOCK_FREE)
-mem_block_cache block_cache;
+mem_block_cache block_cache = { { {nullptr} } } ;
 #elif defined(BOOST_HAS_THREADS)
 mem_block_cache block_cache = { 0, 0, BOOST_STATIC_MUTEX_INIT, };
 #else

--- a/src/regex.cpp
+++ b/src/regex.cpp
@@ -191,10 +191,12 @@ BOOST_REGEX_DECL void BOOST_REGEX_CALL put_mem_block(void* p)
 
 #else
 
-#ifdef BOOST_HAS_THREADS
+#if defined(BOOST_REGEX_MEM_BLOCK_CACHE_LOCK_FREE)
 mem_block_cache block_cache;
+#elif defined(BOOST_HAS_THREADS)
+mem_block_cache block_cache = { 0, 0, BOOST_STATIC_MUTEX_INIT, };
 #else
-mem_block_cache block_cache;
+mem_block_cache block_cache = { 0, 0, };
 #endif
 
 BOOST_REGEX_DECL void* BOOST_REGEX_CALL get_mem_block()

--- a/src/regex.cpp
+++ b/src/regex.cpp
@@ -192,9 +192,9 @@ BOOST_REGEX_DECL void BOOST_REGEX_CALL put_mem_block(void* p)
 #else
 
 #ifdef BOOST_HAS_THREADS
-mem_block_cache block_cache = { 0, 0, BOOST_STATIC_MUTEX_INIT, };
+mem_block_cache block_cache;
 #else
-mem_block_cache block_cache = { 0, 0, };
+mem_block_cache block_cache;
 #endif
 
 BOOST_REGEX_DECL void* BOOST_REGEX_CALL get_mem_block()


### PR DESCRIPTION
This *significantly* improves parallel performance of regex.
Currently if I have a large number of threads all using regexes; even if
they are using idependent regex objects, performance is still extremely poor
due to the lock inside of the mem_block_cache.