### PR TITLE
Fix test on compilers without char32_t

### DIFF
--- a/test/concepts/test_bug_11988.cpp
+++ b/test/concepts/test_bug_11988.cpp
@@ -9,6 +9,7 @@
 *
 */
 
+#include <boost/config.hpp>
 
 #ifndef BOOST_NO_CXX11_CHAR32_T
 


### PR DESCRIPTION
As the include for BOOST_NO_CXX11_CHAR32_T was missing, the test didn't compile.