### PR TITLE
New build-option ICU_LIBPATH to manually provide path to libs of ICU.

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -18,11 +18,11 @@ rule path_options ( properties * )
     local result ;
     if <address-model>64 in $(properties) && <toolset>msvc in $(properties) 
     {
-    	result = <search>$(ICU_PATH)/bin64 <search>$(ICU_PATH)/lib64 ;
+        result = <search>$(ICU_PATH)/bin64 <search>$(ICU_LIBPATH)&&$(ICU_PATH)/lib64 ;
     }
     else
     {
-    	result = <search>$(ICU_PATH)/bin <search>$(ICU_PATH)/lib ;
+        result = <search>$(ICU_PATH)/bin <search>$(ICU_LIBPATH)&&$(ICU_PATH)/lib ;
     }
     return $(result) ;
 }
@@ -34,11 +34,15 @@ if ! $(disable-icu)
 {
 
    if [ modules.peek : ICU_PATH ]
-   {    
+   {
        ICU_PATH =  [ modules.peek : ICU_PATH ] ;
    }
+   if [ modules.peek : ICU_LIBPATH ]
+   {
+       ICU_LIBPATH =  [ modules.peek : ICU_LIBPATH ] ;
+   }
    if [ modules.peek : ICU_LINK ]
-   {    
+   {
        ICU_LINK =  [ modules.peek : ICU_LINK ] ;
    }
 

--- a/build/gcc-shared.mak
+++ b/build/gcc-shared.mak
@@ -14,11 +14,12 @@
 
 #
 # the following environment variables are recognised:
-# ICU_PATH= Path to ICU installation.
-# CXXFLAGS= extra compiler options - note applies to all build variants
-# INCLUDES= additional include directories
-# LDFLAGS=  additional linker options
-# LIBS=     additional library files
+# ICU_PATH=    Path to ICU installation.
+# ICU_LIBPATH= Path to ICU libraries.
+# CXXFLAGS=    extra compiler options - note applies to all build variants
+# INCLUDES=    additional include directories
+# LDFLAGS=     additional linker options
+# LIBS=        additional library files
 
 # compiler:
 CXX?=g++
@@ -39,9 +40,15 @@ $(warning "Hint: set ICU_PATH on the nmake command line to point ")
 $(warning "to your ICU installation if you have one.")
 else
 ICU_CXXFLAGS= -DBOOST_HAS_ICU=1 -I$(ICU_PATH)/include
+ifeq "$(ICU_LIBPATH)" ""
 ICU_LDFLAGS= -L$(ICU_PATH)/lib
 ICU_LIBS= -licui18n -licuuc
 $(warning "Building Boost.Regex with ICU in $(ICU_PATH)")
+else
+ICU_LDFLAGS= -L$(ICU_LIBPATH) -L$(ICU_PATH)/lib
+ICU_LIBS= -licui18n -licuuc
+$(warning "Building Boost.Regex with ICU in $(ICU_PATH) and libs in $(ICU_LIBPATH)")
+endif
 endif
 
 

--- a/build/gcc.mak
+++ b/build/gcc.mak
@@ -14,11 +14,12 @@
 
 #
 # the following environment variables are recognised:
-# ICU_PATH= Path to ICU installation.
-# CXXFLAGS= extra compiler options - note applies to all build variants
-# INCLUDES= additional include directories
-# LDFLAGS=  additional linker options
-# LIBS=     additional library files
+# ICU_PATH=    Path to ICU installation.
+# ICU_LIBPATH= Path to ICU installation.
+# CXXFLAGS=    extra compiler options - note applies to all build variants
+# INCLUDES=    additional include directories
+# LDFLAGS=     additional linker options
+# LIBS=        additional library files
 
 # compiler:
 CXX?=g++
@@ -39,9 +40,15 @@ $(warning "Hint: set ICU_PATH on the nmake command line to point ")
 $(warning "to your ICU installation if you have one.")
 else
 ICU_CXXFLAGS= -DBOOST_HAS_ICU=1 -I$(ICU_PATH)/include
+ifeq "$(ICU_LIBPATH)" ""
 ICU_LDFLAGS= -L$(ICU_PATH)/lib
 ICU_LIBS= -licui18n -licuuc
 $(warning "Building Boost.Regex with ICU in $(ICU_PATH)")
+else
+ICU_LDFLAGS= -L$(ICU_LIBPATH) -L$(ICU_PATH)/lib
+ICU_LIBS= -licui18n -licuuc
+$(warning "Building Boost.Regex with ICU in $(ICU_PATH) and libs in $(ICU_LIBPATH)")
+endif
 endif
 
 

--- a/build/gcc_gen.sh
+++ b/build/gcc_gen.sh
@@ -124,11 +124,12 @@ function gcc_gen()
 
 #
 # the following environment variables are recognised:
-# ICU_PATH= Path to ICU installation.
-# CXXFLAGS= extra compiler options - note applies to all build variants
-# INCLUDES= additional include directories
-# LDFLAGS=  additional linker options
-# LIBS=     additional library files
+# ICU_PATH=    Path to ICU installation.
+# ICU_LIBPATH= Path to ICU library-installation.
+# CXXFLAGS=    extra compiler options - note applies to all build variants
+# INCLUDES=    additional include directories
+# LDFLAGS=     additional linker options
+# LIBS=        additional library files
 
 # compiler:
 CXX?=g++
@@ -149,9 +150,15 @@ ifeq "\$(ICU_PATH)" ""
 \$(warning "to your ICU installation if you have one.")
 else
 ICU_CXXFLAGS= -DBOOST_HAS_ICU=1 -I\$(ICU_PATH)/include
+ifeq "\$(ICU_LIBPATH)" ""
 ICU_LDFLAGS= -L\$(ICU_PATH)/lib
 ICU_LIBS= -licui18n -licuuc
 \$(warning "Building Boost.Regex with ICU in \$(ICU_PATH)")
+else
+ICU_LDFLAGS= -L\$(ICU_LIBPATH) -L\$(ICU_PATH)/lib
+ICU_LIBS= -licui18n -licuuc
+\$(warning "Building Boost.Regex with ICU in \$(ICU_PATH) and its libs in \$(ICU_LIBPATH)")
+endif
 endif
 
 EOF
@@ -208,11 +215,12 @@ function gcc_gen_shared()
 
 #
 # the following environment variables are recognised:
-# ICU_PATH= Path to ICU installation.
-# CXXFLAGS= extra compiler options - note applies to all build variants
-# INCLUDES= additional include directories
-# LDFLAGS=  additional linker options
-# LIBS=     additional library files
+# ICU_PATH=    Path to ICU installation.
+# ICU_LIBPATH= Path to ICU library-installation.
+# CXXFLAGS=    extra compiler options - note applies to all build variants
+# INCLUDES=    additional include directories
+# LDFLAGS=     additional linker options
+# LIBS=        additional library files
 
 # compiler:
 CXX?=g++
@@ -233,9 +241,15 @@ ifeq "\$(ICU_PATH)" ""
 \$(warning "to your ICU installation if you have one.")
 else
 ICU_CXXFLAGS= -DBOOST_HAS_ICU=1 -I\$(ICU_PATH)/include
+ifeq "\$(ICU_LIBPATH)" ""
 ICU_LDFLAGS= -L\$(ICU_PATH)/lib
 ICU_LIBS= -licui18n -licuuc
 \$(warning "Building Boost.Regex with ICU in \$(ICU_PATH)")
+else
+ICU_LDFLAGS= -L\$(ICU_LIBPATH) -L\$(ICU_PATH)/lib
+ICU_LIBS= -licui18n -licuuc
+\$(warning "Building Boost.Regex with ICU in \$(ICU_PATH) and its libs in \$(ICU_LIBPATH)")
+endif
 endif
 
 EOF

--- a/build/vc10.mak
+++ b/build/vc10.mak
@@ -16,6 +16,7 @@
 # path to ICU library installation goes here:
 #
 ICU_PATH=
+ICU_LIBPATH=
 #
 # Add additional compiler options here:
 #
@@ -54,9 +55,15 @@ ICU_LINK_OPTS=
 !MESSAGE Hint: set ICU_PATH on the nmake command line to point 
 !MESSAGE to your ICU installation if you have one.
 !ELSE
+!IF "$(ICU_LIBPATH)" == ""
 ICU_COMPILE_OPTS= -DBOOST_HAS_ICU=1 -I"$(ICU_PATH)\include"
 ICU_LINK_OPTS= /LIBPATH:"$(ICU_PATH)\lib" icuin.lib icuuc.lib
 !MESSAGE Building Boost.Regex with ICU in $(ICU_PATH)
+!ELSE
+ICU_COMPILE_OPTS= -DBOOST_HAS_ICU=1 -I"$(ICU_PATH)\include"
+ICU_LINK_OPTS= /LIBPATH:"$(ICU_LIBPATH)" /LIBPATH:"$(ICU_PATH)\lib" icuin.lib icuuc.lib
+!MESSAGE Building Boost.Regex with ICU in $(ICU_PATH) and libs in $(ICU_LIBPATH)
+!ENDIF
 !ENDIF
 
 

--- a/build/vc6-stlport.mak
+++ b/build/vc6-stlport.mak
@@ -16,6 +16,7 @@
 # ICU setup:
 #
 ICU_PATH=
+ICU_LIBPATH=
 #
 # Add additional compiler options here:
 #
@@ -54,9 +55,15 @@ ICU_LINK_OPTS=
 !MESSAGE Hint: set ICU_PATH on the nmake command line to point 
 !MESSAGE to your ICU installation if you have one.
 !ELSE
+!IF "$(ICU_LIBPATH)" == ""
 ICU_COMPILE_OPTS= -DBOOST_HAS_ICU=1 -I"$(ICU_PATH)\include"
 ICU_LINK_OPTS= /LIBPATH:"$(ICU_PATH)\lib" icuin.lib icuuc.lib
 !MESSAGE Building Boost.Regex with ICU in $(ICU_PATH)
+!ELSE
+ICU_COMPILE_OPTS= -DBOOST_HAS_ICU=1 -I"$(ICU_PATH)\include"
+ICU_LINK_OPTS= /LIBPATH:"$(ICU_LIBPATH)" /LIBPATH:"$(ICU_PATH)\lib" icuin.lib icuuc.lib
+!MESSAGE Building Boost.Regex with ICU in $(ICU_PATH) and libs in $(ICU_LIBPATH)
+!ENDIF
 !ENDIF
 
 

--- a/build/vc6.mak
+++ b/build/vc6.mak
@@ -16,6 +16,7 @@
 # path to ICU library installation goes here:
 #
 ICU_PATH=
+ICU_LIBPATH=
 #
 # Add additional compiler options here:
 #
@@ -54,9 +55,15 @@ ICU_LINK_OPTS=
 !MESSAGE Hint: set ICU_PATH on the nmake command line to point 
 !MESSAGE to your ICU installation if you have one.
 !ELSE
+!IF "$(ICU_PATH)" == ""
 ICU_COMPILE_OPTS= -DBOOST_HAS_ICU=1 -I"$(ICU_PATH)\include"
 ICU_LINK_OPTS= /LIBPATH:"$(ICU_PATH)\lib" icuin.lib icuuc.lib
 !MESSAGE Building Boost.Regex with ICU in $(ICU_PATH)
+!ELSE
+ICU_COMPILE_OPTS= -DBOOST_HAS_ICU=1 -I"$(ICU_PATH)\include"
+ICU_LINK_OPTS= /LIBPATH:"$(ICU_LIBPATH)" /LIBPATH:"$(ICU_PATH)\lib" icuin.lib icuuc.lib
+!MESSAGE Building Boost.Regex with ICU in $(ICU_PATH) and libs in $(ICU_LIBPATH)
+!ENDIF
 !ENDIF
 
 

--- a/build/vc7-stlport.mak
+++ b/build/vc7-stlport.mak
@@ -16,6 +16,7 @@
 # ICU setup:
 #
 ICU_PATH=
+ICU_LIBPATH=
 #
 # Add additional compiler options here:
 #
@@ -54,9 +55,15 @@ ICU_LINK_OPTS=
 !MESSAGE Hint: set ICU_PATH on the nmake command line to point 
 !MESSAGE to your ICU installation if you have one.
 !ELSE
+!IF "$(ICU_LIBPATH)" == ""
 ICU_COMPILE_OPTS= -DBOOST_HAS_ICU=1 -I"$(ICU_PATH)\include"
 ICU_LINK_OPTS= /LIBPATH:"$(ICU_PATH)\lib" icuin.lib icuuc.lib
 !MESSAGE Building Boost.Regex with ICU in $(ICU_PATH)
+!ELSE
+ICU_COMPILE_OPTS= -DBOOST_HAS_ICU=1 -I"$(ICU_PATH)\include"
+ICU_LINK_OPTS= /LIBPATH:"$(ICU_LIBPATH)" /LIBPATH:"$(ICU_PATH)\lib" icuin.lib icuuc.lib
+!MESSAGE Building Boost.Regex with ICU in $(ICU_PATH) and libs in $(ICU_LIBPATH)
+!ENDIF
 !ENDIF
 
 

--- a/build/vc7.mak
+++ b/build/vc7.mak
@@ -16,6 +16,7 @@
 # path to ICU library installation goes here:
 #
 ICU_PATH=
+ICU_LIBPATH=
 #
 # Add additional compiler options here:
 #
@@ -54,9 +55,15 @@ ICU_LINK_OPTS=
 !MESSAGE Hint: set ICU_PATH on the nmake command line to point 
 !MESSAGE to your ICU installation if you have one.
 !ELSE
+!IF "$(ICU_LIBPATH)" == ""
 ICU_COMPILE_OPTS= -DBOOST_HAS_ICU=1 -I"$(ICU_PATH)\include"
 ICU_LINK_OPTS= /LIBPATH:"$(ICU_PATH)\lib" icuin.lib icuuc.lib
 !MESSAGE Building Boost.Regex with ICU in $(ICU_PATH)
+!ELSE
+ICU_COMPILE_OPTS= -DBOOST_HAS_ICU=1 -I"$(ICU_PATH)\include"
+ICU_LINK_OPTS= /LIBPATH:"$(ICU_LIBPATH)" /LIBPATH:"$(ICU_PATH)\lib" icuin.lib icuuc.lib
+!MESSAGE Building Boost.Regex with ICU in $(ICU_PATH) and libs in $(ICU_LIBPATH)
+!ENDIF
 !ENDIF
 
 

--- a/build/vc71-stlport.mak
+++ b/build/vc71-stlport.mak
@@ -16,6 +16,7 @@
 # ICU setup:
 #
 ICU_PATH=
+ICU_LIBPATH=
 #
 # Add additional compiler options here:
 #
@@ -54,9 +55,15 @@ ICU_LINK_OPTS=
 !MESSAGE Hint: set ICU_PATH on the nmake command line to point 
 !MESSAGE to your ICU installation if you have one.
 !ELSE
+!IF "$(ICU_LIBPATH)" == ""
 ICU_COMPILE_OPTS= -DBOOST_HAS_ICU=1 -I"$(ICU_PATH)\include"
 ICU_LINK_OPTS= /LIBPATH:"$(ICU_PATH)\lib" icuin.lib icuuc.lib
 !MESSAGE Building Boost.Regex with ICU in $(ICU_PATH)
+!ELSE
+ICU_COMPILE_OPTS= -DBOOST_HAS_ICU=1 -I"$(ICU_PATH)\include"
+ICU_LINK_OPTS= /LIBPATH:"$(ICU_LIBPATH)" /LIBPATH:"$(ICU_PATH)\lib" icuin.lib icuuc.lib
+!MESSAGE Building Boost.Regex with ICU in $(ICU_PATH) and libs in $(ICU_LIBPATH)
+!ENDIF
 !ENDIF
 
 

--- a/build/vc71.mak
+++ b/build/vc71.mak
@@ -16,6 +16,7 @@
 # path to ICU library installation goes here:
 #
 ICU_PATH=
+ICU_LIBPATH=
 #
 # Add additional compiler options here:
 #
@@ -54,9 +55,15 @@ ICU_LINK_OPTS=
 !MESSAGE Hint: set ICU_PATH on the nmake command line to point 
 !MESSAGE to your ICU installation if you have one.
 !ELSE
+!IF "$(ICU_LIBPATH)" == ""
 ICU_COMPILE_OPTS= -DBOOST_HAS_ICU=1 -I"$(ICU_PATH)\include"
 ICU_LINK_OPTS= /LIBPATH:"$(ICU_PATH)\lib" icuin.lib icuuc.lib
 !MESSAGE Building Boost.Regex with ICU in $(ICU_PATH)
+!ELSE
+ICU_COMPILE_OPTS= -DBOOST_HAS_ICU=1 -I"$(ICU_PATH)\include"
+ICU_LINK_OPTS= /LIBPATH:"$(ICU_LIBPATH)" /LIBPATH:"$(ICU_PATH)\lib" icuin.lib icuuc.lib
+!MESSAGE Building Boost.Regex with ICU in $(ICU_PATH) with $(ICU_LIBPATH)
+!ENDIF
 !ENDIF
 
 

--- a/build/vc8.mak
+++ b/build/vc8.mak
@@ -16,6 +16,7 @@
 # path to ICU library installation goes here:
 #
 ICU_PATH=
+ICU_LIBPATH=
 #
 # Add additional compiler options here:
 #
@@ -54,9 +55,15 @@ ICU_LINK_OPTS=
 !MESSAGE Hint: set ICU_PATH on the nmake command line to point 
 !MESSAGE to your ICU installation if you have one.
 !ELSE
+!IF "$(ICU_LIBPATH)" == ""
 ICU_COMPILE_OPTS= -DBOOST_HAS_ICU=1 -I"$(ICU_PATH)\include"
 ICU_LINK_OPTS= /LIBPATH:"$(ICU_PATH)\lib" icuin.lib icuuc.lib
 !MESSAGE Building Boost.Regex with ICU in $(ICU_PATH)
+!ELSE
+ICU_COMPILE_OPTS= -DBOOST_HAS_ICU=1 -I"$(ICU_PATH)\include"
+ICU_LINK_OPTS= /LIBPATH:"$(ICU_LIBPATH)" /LIBPATH:"$(ICU_PATH)\lib" icuin.lib icuuc.lib
+!MESSAGE Building Boost.Regex with ICU in $(ICU_PATH) and libs in $(ICU_LIBPATH)
+!ENDIF
 !ENDIF
 
 

--- a/build/vc9.mak
+++ b/build/vc9.mak
@@ -16,6 +16,7 @@
 # path to ICU library installation goes here:
 #
 ICU_PATH=
+ICU_LIBPATH=
 #
 # Add additional compiler options here:
 #
@@ -54,9 +55,15 @@ ICU_LINK_OPTS=
 !MESSAGE Hint: set ICU_PATH on the nmake command line to point 
 !MESSAGE to your ICU installation if you have one.
 !ELSE
+!IF "$(ICU_LIBPATH)" == ""
 ICU_COMPILE_OPTS= -DBOOST_HAS_ICU=1 -I"$(ICU_PATH)\include"
 ICU_LINK_OPTS= /LIBPATH:"$(ICU_PATH)\lib" icuin.lib icuuc.lib
 !MESSAGE Building Boost.Regex with ICU in $(ICU_PATH)
+!ELSE
+ICU_COMPILE_OPTS= -DBOOST_HAS_ICU=1 -I"$(ICU_PATH)\include"
+ICU_LINK_OPTS= /LIBPATH:"$(ICU_LIBPATH)" /LIBPATH:"$(ICU_PATH)\lib" icuin.lib icuuc.lib
+!MESSAGE Building Boost.Regex with ICU in $(ICU_PATH) and libs in $(ICU_LIBPATH)
+!ENDIF
 !ENDIF
 
 

--- a/build/vc_gen.sh
+++ b/build/vc_gen.sh
@@ -219,6 +219,7 @@ function vc6_gen()
 # path to ICU library installation goes here:
 #
 ICU_PATH=
+ICU_LIBPATH=
 #
 # Add additional compiler options here:
 #
@@ -257,9 +258,15 @@ ICU_LINK_OPTS=
 !MESSAGE Hint: set ICU_PATH on the nmake command line to point 
 !MESSAGE to your ICU installation if you have one.
 !ELSE
+!IF "\$(ICU_LIBPATH)" == ""
 ICU_COMPILE_OPTS= -DBOOST_HAS_ICU=1 -I"\$(ICU_PATH)\\include"
 ICU_LINK_OPTS= /LIBPATH:"\$(ICU_PATH)\\lib" icuin.lib icuuc.lib
 !MESSAGE Building Boost.Regex with ICU in \$(ICU_PATH)
+!ELSE
+ICU_COMPILE_OPTS= -DBOOST_HAS_ICU=1 -I"\$(ICU_PATH)\\include"
+ICU_LINK_OPTS= /LIBPATH:"\$(ICU_LIBPATH)" /LIBPATH:"\$(ICU_PATH)\\lib" icuin.lib icuuc.lib
+!MESSAGE Building Boost.Regex with ICU in \$(ICU_PATH) and libs in \$(ICU_LIBPATH)
+!ENDIF
 !ENDIF
 
 EOF
@@ -351,6 +358,7 @@ function vc6_stlp_gen()
 # ICU setup:
 #
 ICU_PATH=
+ICU_LIBPATH=
 #
 # Add additional compiler options here:
 #
@@ -389,9 +397,15 @@ ICU_LINK_OPTS=
 !MESSAGE Hint: set ICU_PATH on the nmake command line to point 
 !MESSAGE to your ICU installation if you have one.
 !ELSE
+!IF "\$(ICU_LIBPATH)" == ""
 ICU_COMPILE_OPTS= -DBOOST_HAS_ICU=1 -I"\$(ICU_PATH)\\include"
 ICU_LINK_OPTS= /LIBPATH:"\$(ICU_PATH)\\lib" icuin.lib icuuc.lib
 !MESSAGE Building Boost.Regex with ICU in \$(ICU_PATH)
+!ELSE
+ICU_COMPILE_OPTS= -DBOOST_HAS_ICU=1 -I"\$(ICU_PATH)\\include"
+ICU_LINK_OPTS= /LIBPATH:"\$(ICU_LIBPATH)" /LIBPATH:"\$(ICU_PATH)\\lib" icuin.lib icuuc.lib
+!MESSAGE Building Boost.Regex with ICU in \$(ICU_PATH) and libs in \$(ICU_LIBPATH)
+!ENDIF
 !ENDIF
 
 EOF

--- a/doc/html/boost_regex/install.html
+++ b/doc/html/boost_regex/install.html
@@ -136,6 +136,11 @@
       might use:
     </p>
 <pre class="programlisting">bjam -sICU_PATH=c:\download\icu --toolset=toolset-name install</pre>
+<p>
+      If your libraries are in a different (sub)directory then you can additionally use <code class="computeroutput"><span class="identifier">ICU_LIBPATH</span></code>
+      to explicitly point to the correct directory where the ICU libraries are located.
+    </p>
+<pre class="programlisting">bjam -sICU_PATH=c:\download\icu -sICU_LIBPATH=c:\download\icu\debug-libs --toolset=toolset-name install</pre>
 <div class="important"><table border="0" summary="Important">
 <tr>
 <td rowspan="2" align="center" valign="top" width="25"><img alt="[Important]" src="../../../../../doc/src/images/important.png"></td>

--- a/doc/install.qbk
+++ b/doc/install.qbk
@@ -87,6 +87,11 @@ might use:
 
 [pre bjam -sICU_PATH=c:\download\icu --toolset=toolset-name install]
 
+If your libraries are in a different (sub)directory then you can additionally use `ICU_LIBPATH`
+to explicitly point to the correct directory where the ICU libraries are located.
+
+[pre bjam -sICU_PATH=c:\download\icu -sICU_LIBPATH=C:\download\icu\debug-libs --toolset=toolset-name install]
+
 [important ICU is a C++ library just like Boost is, as such your copy of 
 ICU must have been built with the same C++ compiler (and compiler version) 
 that you are using to build Boost.  Boost.Regex will not work correctly unless 


### PR DESCRIPTION
When using _Boost.Build_ to build _**Boost.Regex**_ one can build and link with the external library **ICU** and provide the path to its (root-)directory using the option `ICU_PATH`. The ICU library files are searched in a sub-directory `lib` (or in some situations in `lib64`) of _`<ICU_PATH>`_.
However, that only works if the library files are directly located in `<ICU_PATH>/lib` (or `<ICU_PATH>/lib64`).

If they are installed in a custom location,
* either a totally different location,
* another named sub-directory (e.g. `<ICU_PATH>/libraries` ) or
* even in a sub-directory of the expected sub-directory (e.g. `<ICU_PATH>/lib/x86_64-linux-gnu`),

this does no longer work and the ICU libs cannot be found.

Therefore, this pull-request provides an additional _Boost.Build_ option `ICU_LIBPATH` with which one can provide the path to the directory where the **ICU** libraries are located.