### PR TITLE
Conditionally replace deprecated/removed C++98 std::bind1st by std::b…

### DIFF
--- a/example/snippets/regex_grep_example_3.cpp
+++ b/example/snippets/regex_grep_example_3.cpp
@@ -89,6 +89,11 @@ void class_index::IndexClasses(const std::string& file)
             start,
             end,
             expression);
+#elif defined(BOOST_NO_CXX98_BINDERS)
+   boost::regex_grep(std::bind(&class_index::grep_callback, this, std::placeholders::_1),
+            start,
+            end,
+            expression);
 #else
    boost::regex_grep(std::bind1st(std::mem_fun(&class_index::grep_callback), this),
             start,


### PR DESCRIPTION
…ind.

Signed-off-by: Daniela Engert <dani@ngrt.de>