### PR TITLE
Fix bug 13036: overflow in estimate_max_state_count

### DIFF
--- a/include/boost/regex/v4/perl_matcher_common.hpp
+++ b/include/boost/regex/v4/perl_matcher_common.hpp
@@ -110,9 +110,14 @@ void perl_matcher<BidiIterator, Allocator, traits>::estimate_max_state_count(std
    std::ptrdiff_t dist = boost::BOOST_REGEX_DETAIL_NS::distance(base, last);
    if(dist == 0)
       dist = 1;
-   std::ptrdiff_t states = re.size();
+   std::size_t states = re.size();
    if(states == 0)
       states = 1;
+   else if((std::numeric_limits<std::ptrdiff_t>::max)() / states < states)
+   {
+      max_state_count = (std::min)((std::ptrdiff_t)BOOST_REGEX_MAX_STATE_COUNT, (std::numeric_limits<std::ptrdiff_t>::max)() - 2);
+      return;
+   }
    states *= states;
    if((std::numeric_limits<std::ptrdiff_t>::max)() / dist < states)
    {


### PR DESCRIPTION
Address Bug 13036 [Boost.Regex: Integer overflow during calculation of max_state_count](https://svn.boost.org/trac10/ticket/13036).

Add overflow check on states variable multiplied with itself and introduce guarantee that initialization of states can contain the full range of values potentially returned by re.size().

Ran Boost.Regex test suite using g++ (GCC) 4.8.5 20150623 (Red Hat 4.8.5-11) on CentOS 7-1611 using 3.10.0-514.21.2.el7.x86_64 and 3.10.0-514.21.2.el7.centos.plus.i686.  All tests passed. No warnings introduced as a result of this change.