### PR TITLE
Fix bash path in shebangs

### DIFF
--- a/build/bc_gen.sh
+++ b/build/bc_gen.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 # copyright John Maddock 2003
 # Distributed under the Boost Software License, Version 1.0. 

--- a/build/gcc_gen.sh
+++ b/build/gcc_gen.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 # copyright John Maddock 2003
 # Distributed under the Boost Software License, Version 1.0. 

--- a/build/generic_gen.sh
+++ b/build/generic_gen.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 # copyright John Maddock 2003
 # Distributed under the Boost Software License, Version 1.0. 

--- a/build/sun_gen.sh
+++ b/build/sun_gen.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 # copyright John Maddock 2003
 # Distributed under the Boost Software License, Version 1.0. 

--- a/build/vc_gen.sh
+++ b/build/vc_gen.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 # copyright John Maddock 2003
 # Distributed under the Boost Software License, Version 1.0. 


### PR DESCRIPTION
"/bin/bash" is a Linuxism.  "/usr/bin/env bash" is portable.