### PR TITLE
Add missing include to config.hpp to primary_transform.hpp

### DIFF
--- a/include/boost/regex/v4/primary_transform.hpp
+++ b/include/boost/regex/v4/primary_transform.hpp
@@ -20,6 +20,10 @@
 #ifndef BOOST_REGEX_PRIMARY_TRANSFORM
 #define BOOST_REGEX_PRIMARY_TRANSFORM
 
+#ifndef BOOST_REGEX_CONFIG_HPP
+#include <boost/regex/config.hpp>
+#endif
+
 #ifdef BOOST_MSVC
 #pragma warning(push)
 #pragma warning(disable: 4103)


### PR DESCRIPTION
This header declares a namespace with the BOOST_REGEX_DETAIL_NS
token from the config.hpp header, but never includes this header
unlike the other headers in this directory.
This means that if a user includes this header first, suddenly
all declarations are inside the literal 'BOOST_REGEX_DETAIL_NS'
namespace which breaks all code using this header.