### PR TITLE
Inheritance from std::iterator is deprecated in c++17. Therefore repl…

### DIFF
--- a/example/timer/regex_timer.cpp
+++ b/example/timer/regex_timer.cpp
@@ -67,11 +67,7 @@ ostream& operator << (ostream& os, const std::wstring& s)
 
 template <class S>
 class string_out_iterator 
-#ifndef BOOST_NO_STD_ITERATOR
-  : public std::iterator<std::output_iterator_tag, void, void, void, void>
-#endif // ndef BOOST_NO_STD_ITERATOR
 {
-#ifdef BOOST_NO_STD_ITERATOR
 public:
    typedef std::output_iterator_tag iterator_category;
    typedef void value_type;
@@ -79,8 +75,6 @@ public:
    typedef void pointer;
    typedef void reference;
 private:
-#endif // BOOST_NO_STD_ITERATOR
-
    S* out;
 public:
    string_out_iterator(S& s) : out(&s) {}

--- a/include/boost/regex/v4/fileiter.hpp
+++ b/include/boost/regex/v4/fileiter.hpp
@@ -195,9 +195,6 @@ public:
 };
 
 class BOOST_REGEX_DECL mapfile_iterator
-#if !defined(BOOST_NO_STD_ITERATOR) || defined(BOOST_MSVC_STD_ITERATOR)
-: public std::iterator<std::random_access_iterator_tag, char>
-#endif
 {
    typedef mapfile::pointer internal_pointer;
    internal_pointer* node;

--- a/include/boost/regex/v4/regex_format.hpp
+++ b/include/boost/regex/v4/regex_format.hpp
@@ -800,9 +800,6 @@ void basic_regex_formatter<OutputIterator, Results, traits, ForwardIter>::put(co
 
 template <class S>
 class string_out_iterator
-#ifndef BOOST_NO_STD_ITERATOR
-   : public std::iterator<std::output_iterator_tag, typename S::value_type>
-#endif
 {
    S* out;
 public:
@@ -816,13 +813,11 @@ public:
       return *this; 
    }
 
-#ifdef BOOST_NO_STD_ITERATOR
    typedef std::ptrdiff_t difference_type;
    typedef typename S::value_type value_type;
    typedef value_type* pointer;
    typedef value_type& reference;
    typedef std::output_iterator_tag iterator_category;
-#endif
 };
 
 template <class OutputIterator, class Iterator, class Alloc, class ForwardIter, class traits>

--- a/include/boost/regex/v4/regex_iterator.hpp
+++ b/include/boost/regex/v4/regex_iterator.hpp
@@ -85,14 +85,6 @@ template <class BidirectionalIterator,
           class charT = BOOST_DEDUCED_TYPENAME BOOST_REGEX_DETAIL_NS::regex_iterator_traits<BidirectionalIterator>::value_type,
           class traits = regex_traits<charT> >
 class regex_iterator 
-#ifndef BOOST_NO_STD_ITERATOR
-   : public std::iterator<
-         std::forward_iterator_tag, 
-         match_results<BidirectionalIterator>,
-         typename BOOST_REGEX_DETAIL_NS::regex_iterator_traits<BidirectionalIterator>::difference_type,
-         const match_results<BidirectionalIterator>*,
-         const match_results<BidirectionalIterator>& >         
-#endif
 {
 private:
    typedef regex_iterator_implementation<BidirectionalIterator, charT, traits> impl;

--- a/include/boost/regex/v4/regex_token_iterator.hpp
+++ b/include/boost/regex/v4/regex_token_iterator.hpp
@@ -167,14 +167,6 @@ template <class BidirectionalIterator,
           class charT = BOOST_DEDUCED_TYPENAME BOOST_REGEX_DETAIL_NS::regex_iterator_traits<BidirectionalIterator>::value_type,
           class traits = regex_traits<charT> >
 class regex_token_iterator 
-#ifndef BOOST_NO_STD_ITERATOR
-   : public std::iterator<
-         std::forward_iterator_tag, 
-         sub_match<BidirectionalIterator>,
-         typename BOOST_REGEX_DETAIL_NS::regex_iterator_traits<BidirectionalIterator>::difference_type,
-         const sub_match<BidirectionalIterator>*,
-         const sub_match<BidirectionalIterator>& >         
-#endif
 {
 private:
    typedef regex_token_iterator_implementation<BidirectionalIterator, charT, traits> impl;

--- a/include/boost/regex/v4/u32regex_iterator.hpp
+++ b/include/boost/regex/v4/u32regex_iterator.hpp
@@ -72,14 +72,6 @@ private:
 
 template <class BidirectionalIterator>
 class u32regex_iterator 
-#ifndef BOOST_NO_STD_ITERATOR
-   : public std::iterator<
-         std::forward_iterator_tag, 
-         match_results<BidirectionalIterator>,
-         typename BOOST_REGEX_DETAIL_NS::regex_iterator_traits<BidirectionalIterator>::difference_type,
-         const match_results<BidirectionalIterator>*,
-         const match_results<BidirectionalIterator>& >         
-#endif
 {
 private:
    typedef u32regex_iterator_implementation<BidirectionalIterator> impl;

--- a/include/boost/regex/v4/u32regex_token_iterator.hpp
+++ b/include/boost/regex/v4/u32regex_token_iterator.hpp
@@ -155,14 +155,6 @@ private:
 
 template <class BidirectionalIterator>
 class u32regex_token_iterator 
-#ifndef BOOST_NO_STD_ITERATOR
-   : public std::iterator<
-         std::forward_iterator_tag, 
-         sub_match<BidirectionalIterator>,
-         typename BOOST_REGEX_DETAIL_NS::regex_iterator_traits<BidirectionalIterator>::difference_type,
-         const sub_match<BidirectionalIterator>*,
-         const sub_match<BidirectionalIterator>& >         
-#endif
 {
 private:
    typedef u32regex_token_iterator_implementation<BidirectionalIterator> impl;

--- a/test/regress/test_icu.cpp
+++ b/test/regress/test_icu.cpp
@@ -33,16 +33,16 @@ namespace unnecessary_fix{
 //
 template <class Seq>
 class back_insert_iterator 
-#ifndef BOOST_NO_STD_ITERATOR
-   : public std::iterator<std::output_iterator_tag,void,void,void,void>
-#endif
 {
 private:
    Seq* container;
 public:
    typedef const typename Seq::value_type value_type;
    typedef Seq                  container_type;
-   typedef std::output_iterator_tag  iterator_category;
+   typedef void                     difference_type;
+   typedef void                     pointer;
+   typedef void                     reference;
+   typedef std::output_iterator_tag iterator_category;
 
    explicit back_insert_iterator(Seq& x) : container(&x) {}
    back_insert_iterator& operator=(const value_type& val) 


### PR DESCRIPTION
Inheritance from std::iterator is deprecated in c++17. Therefore replace it by lifting it's members into the derived class. Fortunately, this is already done in Boost.Regex so that dropping the inheritance is a no-brainer.

Signed-off-by: Daniela Engert <dani@ngrt.de>