### PR TITLE
Fixed typo in exception text

### DIFF
--- a/include/boost/regex/v4/match_results.hpp
+++ b/include/boost/regex/v4/match_results.hpp
@@ -569,7 +569,7 @@ private:
    //
    static void raise_logic_error()
    {
-      std::logic_error e("Attempt to access an uninitialzed boost::match_results<> class.");
+      std::logic_error e("Attempt to access an uninitialized boost::match_results<> class.");
       boost::throw_exception(e);
    }
 


### PR DESCRIPTION
Fixed a typo in an exception message in file match_results.hpp.