### PR TITLE
Fixes a potentional crash with certain regexes

### DIFF
--- a/include/boost/regex/v4/match_results.hpp
+++ b/include/boost/regex/v4/match_results.hpp
@@ -241,7 +241,7 @@ public:
       //
       // Scan for the leftmost *matched* subexpression with the specified named:
       //
-      if(m_is_singular)
+      if(m_is_singular || !m_named_subs)
          raise_logic_error();
       BOOST_REGEX_DETAIL_NS::named_subexpressions::range_type r = m_named_subs->equal_range(i, j);
       while((r.first != r.second) && ((*this)[r.first->index].matched == false))


### PR DESCRIPTION
Some regular expressions with nested tags can cause a crash in boost::match_results::format(...). With this fix it will throw an exception instead of dying. 