### PR TITLE
resolve some warnings

### DIFF
--- a/include/boost/regex/concepts.hpp
+++ b/include/boost/regex/concepts.hpp
@@ -437,7 +437,8 @@ struct BaseRegexConcept
       ignore_unused_variable_warning(bi);
       sub_diff_type diff = m_sub.length();
       ignore_unused_variable_warning(diff);
-      // match_results tests:
+      // match_results tests - some typedefs are not used, however these
+      // guarante that they exist (some compilers may warn on non-usage)
       typedef typename match_results_type::value_type mr_value_type;
       typedef typename match_results_type::const_reference mr_const_reference;
       typedef typename match_results_type::reference mr_reference;
@@ -483,7 +484,7 @@ struct BaseRegexConcept
       mrci = m_cresults.end();
       ignore_unused_variable_warning(mrci);
 
-      mr_allocator_type at2 = m_cresults.get_allocator();
+      (void) m_cresults.get_allocator();
       m_results.swap(m_results);
       global_regex_namespace::swap(m_results, m_results);
 

--- a/src/fileiter.cpp
+++ b/src/fileiter.cpp
@@ -832,7 +832,7 @@ bool iswild(const char* mask, const char* name)
             ++mask;
             continue;
          }
-         // fall through:
+         // fall through
       default:
          if(BOOST_REGEX_FI_TRANSLATE(*mask) != BOOST_REGEX_FI_TRANSLATE(*name))
             return false;

--- a/src/icu.cpp
+++ b/src/icu.cpp
@@ -481,7 +481,7 @@ icu_regex_traits::string_type icu_regex_traits::lookup_collatename(const char_ty
 bool icu_regex_traits::isctype(char_type c, char_class_type f) const
 {
    // check for standard catagories first:
-   char_class_type m = char_class_type(1uLL << u_charType(c));
+   char_class_type m = char_class_type(static_cast<char_class_type>(1) << u_charType(c));
    if((m & f) != 0) 
       return true;
    // now check for special cases:

--- a/test/c_compiler_checks/posix_api_check.c
+++ b/test/c_compiler_checks/posix_api_check.c
@@ -39,7 +39,7 @@ int main()
    {
       char buf[256];
       regerrorA(result, &re, buf, sizeof(buf));
-      printf(buf);
+      puts(buf);
       return result;
    }
    assert(re.re_nsub == 0);
@@ -50,7 +50,7 @@ int main()
    {
       char buf[256];
       regerrorA(result, &re, buf, sizeof(buf));
-      printf(buf);
+      puts(buf);
       regfreeA(&re);
       return result;
    }

--- a/test/c_compiler_checks/wide_posix_api_check.c
+++ b/test/c_compiler_checks/wide_posix_api_check.c
@@ -50,7 +50,7 @@ int main()
       regerror(result, &re, buf, sizeof(buf));
       for(i = 0; i < 256; ++i)
          nbuf[i] = (char)(buf[i]);
-      printf(nbuf);
+      puts(nbuf);
       return result;
    }
    if(re.re_nsub != 0)
@@ -66,7 +66,7 @@ int main()
       regerror(result, &re, buf, sizeof(buf));
       for(i = 0; i < 256; ++i)
          nbuf[i] = (char)(buf[i]);
-      printf(nbuf);
+      puts(nbuf);
       regfree(&re);
       return result;
    }

--- a/test/captures/captures_test.cpp
+++ b/test/captures/captures_test.cpp
@@ -29,9 +29,9 @@
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
 
 template <int N>
-int array_size(const char* (&p)[N])
+size_t array_size(const char* (&p)[N])
 {
-   for(int i = 0; i < N; ++i)
+   for(size_t i = 0; i < N; ++i)
       if(p[i] == 0)
          return i;
    return N;

--- a/test/test_macros.hpp
+++ b/test/test_macros.hpp
@@ -65,8 +65,8 @@ void report_unexpected_exception(const E& e, int severity, const char* file, int
 }
 
 #define BOOST_MP_UNEXPECTED_EXCEPTION_CHECK(severity) \
-   catch(const std::exception& e) \
-   {  report_unexpected_exception(e, severity, __FILE__, __LINE__, BOOST_CURRENT_FUNCTION); }\
+   catch(const std::exception& __e) \
+   {  report_unexpected_exception(__e, severity, __FILE__, __LINE__, BOOST_CURRENT_FUNCTION); }\
    catch(...)\
    {  BOOST_LIGHTWEIGHT_TEST_OSTREAM << "Exception of unknown type was thrown" << std::endl; report_severity(severity); }
 

--- a/test/unicode/unicode_iterator_test.cpp
+++ b/test/unicode/unicode_iterator_test.cpp
@@ -157,22 +157,30 @@ void spot_checks()
 void test(const std::vector< ::boost::uint32_t>& v)
 {
    typedef std::vector< ::boost::uint32_t> vector32_type;
+#ifdef TEST_UTF16
    typedef std::vector< ::boost::uint16_t> vector16_type;
+#endif
    typedef std::vector< ::boost::uint8_t>  vector8_type;
+#ifdef TEST_UTF16
    typedef boost::u32_to_u16_iterator<vector32_type::const_iterator, ::boost::uint16_t> u32to16type;
    typedef boost::u16_to_u32_iterator<vector16_type::const_iterator, ::boost::uint32_t> u16to32type;
 #if !defined(BOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION) && !defined(BOOST_NO_STD_ITERATOR) && !defined(_RWSTD_NO_CLASS_PARTIAL_SPEC)
    typedef std::reverse_iterator<u32to16type> ru32to16type;
    typedef std::reverse_iterator<u16to32type> ru16to32type;
 #endif
+#endif // TEST_UTF16
+#ifdef TEST_UTF8
    typedef boost::u32_to_u8_iterator<vector32_type::const_iterator, ::boost::uint8_t> u32to8type;
    typedef boost::u8_to_u32_iterator<vector8_type::const_iterator, ::boost::uint32_t> u8to32type;
 #if !defined(BOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION) && !defined(BOOST_NO_STD_ITERATOR) && !defined(_RWSTD_NO_CLASS_PARTIAL_SPEC)
    typedef std::reverse_iterator<u32to8type> ru32to8type;
    typedef std::reverse_iterator<u8to32type> ru8to32type;
 #endif
+#endif // TEST_UTF8
    vector8_type  v8;
+#ifdef TEST_UTF16
    vector16_type v16;
+#endif
    vector32_type v32;
    vector32_type::const_iterator i, j, k;
 


### PR DESCRIPTION
This addresses part of #62 
Let's see how it fares in CI.
I was able to build the following successfully with gcc 7.3 (Ubuntu Bionic):

```
boost@7d92b0355630:/boost/libs/regex/test$ ../../../b2 -q warnings-as-errors=on cxxflags="-Wno-unused-local-typedefs" cxxflags="-Wno-unused-but-set-variable"
```