### PR TITLE
Tentative fix for msvc warnings.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,6 +103,42 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - os: linux
+      env: TOOLSET=gcc COMPILER=g++-7 CXXSTD=03,11 CXXSTD_DIALECT=cxxstd-dialect=gnu
+      addons:
+        apt:
+          packages:
+            - g++-7
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      env: TOOLSET=gcc COMPILER=g++-7 CXXSTD=14,1z CXXSTD_DIALECT=cxxstd-dialect=gnu
+      addons:
+        apt:
+          packages:
+            - g++-7
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      env: TOOLSET=gcc COMPILER=g++-8 CXXSTD=03,11 CXXSTD_DIALECT=cxxstd-dialect=gnu
+      addons:
+        apt:
+          packages:
+            - g++-8
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      env: TOOLSET=gcc COMPILER=g++-8 CXXSTD=14,1z CXXSTD_DIALECT=cxxstd-dialect=gnu
+      addons:
+        apt:
+          packages:
+            - g++-8
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
       env: TOOLSET=clang COMPILER=clang++ CXXSTD=03,11
 
     - os: linux

--- a/include/boost/regex/config.hpp
+++ b/include/boost/regex/config.hpp
@@ -201,7 +201,10 @@
 #  define BOOST_REGEX_HAS_OTHER_WCHAR_T
 #  ifdef BOOST_MSVC
 #     pragma warning(push)
-#     pragma warning(disable : 4251 4231)
+#     pragma warning(disable : 4251)
+#if BOOST_MSVC < 1700
+#     pragma warning(disable : 4231)
+#endif
 #     if BOOST_MSVC < 1600
 #        pragma warning(disable : 4660)
 #     endif

--- a/include/boost/regex/v4/basic_regex.hpp
+++ b/include/boost/regex/v4/basic_regex.hpp
@@ -36,9 +36,15 @@
 namespace boost{
 #ifdef BOOST_MSVC
 #pragma warning(push)
-#pragma warning(disable : 4251 4231 4800)
+#pragma warning(disable : 4251)
+#if BOOST_MSVC < 1700
+#     pragma warning(disable : 4231)
+#endif
 #if BOOST_MSVC < 1600
 #pragma warning(disable : 4660)
+#endif
+#if BOOST_MSVC < 1910
+#pragma warning(disable:4800)
 #endif
 #endif
 

--- a/include/boost/regex/v4/basic_regex_creator.hpp
+++ b/include/boost/regex/v4/basic_regex_creator.hpp
@@ -33,7 +33,9 @@
 
 #ifdef BOOST_MSVC
 #  pragma warning(push)
-#  pragma warning(disable: 4800)
+#if BOOST_MSVC < 1910
+#pragma warning(disable:4800)
+#endif
 #endif
 
 namespace boost{

--- a/include/boost/regex/v4/basic_regex_parser.hpp
+++ b/include/boost/regex/v4/basic_regex_parser.hpp
@@ -35,7 +35,10 @@ namespace BOOST_REGEX_DETAIL_NS{
 
 #ifdef BOOST_MSVC
 #pragma warning(push)
-#pragma warning(disable:4244 4800)
+#pragma warning(disable:4244)
+#if BOOST_MSVC < 1910
+#pragma warning(disable:4800)
+#endif
 #endif
 
 inline boost::intmax_t umax(mpl::false_ const&)

--- a/include/boost/regex/v4/instances.hpp
+++ b/include/boost/regex/v4/instances.hpp
@@ -124,7 +124,9 @@ template class BOOST_REGEX_TEMPLATE_DECL ::boost::BOOST_REGEX_DETAIL_NS::perl_ma
 
 #ifdef __clang__
 #pragma clang diagnostic push
+#if (__clang_major__ > 3) || ((__clang_major__ == 3) && (__clang_minor__ > 5))
 #pragma clang diagnostic ignored "-Wkeyword-macro"
+#endif
 #endif
 
 #  ifndef BOOST_REGEX_INSTANTIATE

--- a/include/boost/regex/v4/instances.hpp
+++ b/include/boost/regex/v4/instances.hpp
@@ -84,7 +84,10 @@ template class BOOST_REGEX_DECL ::boost::BOOST_REGEX_DETAIL_NS::perl_matcher<BOO
 
 #  ifdef BOOST_MSVC
 #     pragma warning(push)
-#     pragma warning(disable : 4251 4231)
+#     pragma warning(disable : 4251)
+#if BOOST_MSVC < 1700
+#     pragma warning(disable : 4231)
+#endif
 #     if BOOST_MSVC < 1600
 #     pragma warning(disable : 4660)
 #     endif

--- a/include/boost/regex/v4/instances.hpp
+++ b/include/boost/regex/v4/instances.hpp
@@ -122,11 +122,17 @@ template class BOOST_REGEX_TEMPLATE_DECL ::boost::BOOST_REGEX_DETAIL_NS::perl_ma
 
 #elif (defined(__GNUC__) && (__GNUC__ >= 3)) || !defined(BOOST_NO_CXX11_EXTERN_TEMPLATE)
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#if (__clang_major__ > 3) || ((__clang_major__ == 3) && (__clang_minor__ > 5))
-#pragma clang diagnostic ignored "-Wkeyword-macro"
-#endif
+#if defined(__clang__)
+#  pragma clang diagnostic push
+#  if defined(__APPLE_CC__)
+#    if (__clang_major__ > 6)
+#      pragma clang diagnostic ignored "-Wkeyword-macro"
+#    endif
+#  else
+#    if (__clang_major__ > 3) || ((__clang_major__ == 3) && (__clang_minor__ > 5))
+#      pragma clang diagnostic ignored "-Wkeyword-macro"
+#    endif
+#  endif
 #endif
 
 #  ifndef BOOST_REGEX_INSTANTIATE

--- a/include/boost/regex/v4/match_results.hpp
+++ b/include/boost/regex/v4/match_results.hpp
@@ -33,7 +33,10 @@
 namespace boost{
 #ifdef BOOST_MSVC
 #pragma warning(push)
-#pragma warning(disable : 4251 4231)
+#pragma warning(disable : 4251)
+#if BOOST_MSVC < 1700
+#     pragma warning(disable : 4231)
+#endif
 #  if BOOST_MSVC < 1600
 #     pragma warning(disable : 4660)
 #  endif

--- a/include/boost/regex/v4/perl_matcher.hpp
+++ b/include/boost/regex/v4/perl_matcher.hpp
@@ -27,7 +27,9 @@
 
 #ifdef BOOST_MSVC
 #  pragma warning(push)
-#  pragma warning(disable: 4800)
+#if BOOST_MSVC < 1910
+#pragma warning(disable:4800)
+#endif
 #endif
 
 namespace boost{
@@ -353,7 +355,10 @@ struct recursion_info
 
 #ifdef BOOST_MSVC
 #pragma warning(push)
-#pragma warning(disable : 4251 4231)
+#pragma warning(disable : 4251)
+#if BOOST_MSVC < 1700
+#     pragma warning(disable : 4231)
+#endif
 #  if BOOST_MSVC < 1600
 #     pragma warning(disable : 4660)
 #  endif

--- a/include/boost/regex/v4/perl_matcher_common.hpp
+++ b/include/boost/regex/v4/perl_matcher_common.hpp
@@ -36,7 +36,9 @@
 #endif
 #ifdef BOOST_MSVC
 #  pragma warning(push)
-#  pragma warning(disable: 4800)
+#if BOOST_MSVC < 1910
+#pragma warning(disable:4800)
+#endif
 #endif
 
 namespace boost{

--- a/include/boost/regex/v4/perl_matcher_non_recursive.hpp
+++ b/include/boost/regex/v4/perl_matcher_non_recursive.hpp
@@ -34,7 +34,10 @@
 #endif
 #ifdef BOOST_MSVC
 #  pragma warning(push)
-#  pragma warning(disable: 4800 4706)
+#  pragma warning(disable: 4706)
+#if BOOST_MSVC < 1910
+#pragma warning(disable:4800)
+#endif
 #endif
 
 namespace boost{

--- a/include/boost/regex/v4/regex_raw_buffer.hpp
+++ b/include/boost/regex/v4/regex_raw_buffer.hpp
@@ -138,12 +138,12 @@ public:
 
    size_type BOOST_REGEX_CALL size()
    {
-      return end - start;
+      return size_type(end - start);
    }
 
    size_type BOOST_REGEX_CALL capacity()
    {
-      return last - start;
+      return size_type(last - start);
    }
 
    void* BOOST_REGEX_CALL data()const
@@ -153,7 +153,7 @@ public:
 
    size_type BOOST_REGEX_CALL index(void* ptr)
    {
-      return static_cast<pointer>(ptr) - static_cast<pointer>(data());
+      return size_type(static_cast<pointer>(ptr) - static_cast<pointer>(data()));
    }
 
    void BOOST_REGEX_CALL clear()

--- a/include/boost/regex/v4/regex_split.hpp
+++ b/include/boost/regex/v4/regex_split.hpp
@@ -36,7 +36,9 @@ namespace boost{
 
 #ifdef BOOST_MSVC
 #  pragma warning(push)
-#  pragma warning(disable: 4800)
+#if BOOST_MSVC < 1910
+#pragma warning(disable:4800)
+#endif
 #endif
 
 namespace BOOST_REGEX_DETAIL_NS{

--- a/include/boost/regex/v4/regex_traits_defaults.hpp
+++ b/include/boost/regex/v4/regex_traits_defaults.hpp
@@ -241,7 +241,7 @@ inline std::ptrdiff_t global_length<char>(const char* p)
 template<>
 inline std::ptrdiff_t global_length<wchar_t>(const wchar_t* p)
 {
-   return (std::wcslen)(p);
+   return (std::ptrdiff_t)(std::wcslen)(p);
 }
 #endif
 template <class charT>

--- a/include/boost/regex/v4/w32_regex_traits.hpp
+++ b/include/boost/regex/v4/w32_regex_traits.hpp
@@ -51,7 +51,9 @@
 #ifdef BOOST_MSVC
 #pragma warning(push)
 #pragma warning(disable:4786)
+#if BOOST_MSVC < 1910
 #pragma warning(disable:4800)
+#endif
 #endif
 
 namespace boost{ 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -196,3 +196,8 @@ build-project ../example ;
 
 # `quick` target (for CI)
 run quick.cpp ../build//boost_regex ;
+
+compile test_warnings.cpp 
+   :     <toolset>msvc:<warnings>all <toolset>msvc:<warnings-as-errors>on
+         <toolset>gcc:<warnings>all <toolset>gcc:<warnings-as-errors>on
+         <toolset>clang:<warnings>all <toolset>clang:<warnings-as-errors>on ;

--- a/test/test_warnings.cpp
+++ b/test/test_warnings.cpp
@@ -1,5 +1,21 @@
+/*
+*
+* Copyright (c) 2018
+* John Maddock
+*
+* Use, modification and distribution are subject to the
+* Boost Software License, Version 1.0. (See accompanying file
+* LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+*
+*/
+
+
 #ifdef _MSC_VER
 #pragma warning(disable:4820 4668)
+#endif
+
+#ifdef __APPLE_CC__
+#pragma clang diagnostic ignored "-Wc++11-long-long"
 #endif
 
 #include <boost/regex.hpp>
@@ -10,3 +26,4 @@ void test_proc()
    boost::regex exp(re);
    regex_match(text, exp);
 }
+

--- a/test/test_warnings.cpp
+++ b/test/test_warnings.cpp
@@ -1,0 +1,12 @@
+#ifdef _MSC_VER
+#pragma warning(disable:4820 4668)
+#endif
+
+#include <boost/regex.hpp>
+
+void test_proc()
+{
+   std::string text, re;
+   boost::regex exp(re);
+   regex_match(text, exp);
+}


### PR DESCRIPTION
See https://github.com/boostorg/regex/issues/61.
Adds warning test case.