### PR TITLE
Workaround clang not exporting symbols when hidden visibility is in effect

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -9,6 +9,7 @@ import testing ;
 project : requirements
    # default to all warnings on:
    <warnings>all
+   <toolset>clang:<visibility>global
    ;
 
 local disable-icu = [ MATCH (--disable-icu) : [ modules.peek : ARGV ] ] ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -21,6 +21,7 @@ project
       #<toolset>gcc-mingw:<link>static
       <toolset>gcc-cygwin:<link>static
       <toolset>sun:<link>static
+      <toolset>clang:<visibility>global
     ;
 
 #


### PR DESCRIPTION
This temporary workaround forces global (a.k.a. "default") visibility by default
when building the library or tests with clang. A proper fix would involve
figuring out what causes the compiler to not export the missing symbols
and adjusting the code accordingly.

This is related to https://github.com/boostorg/regex/issues/49 and https://github.com/boostorg/boost/pull/190.
