### PR TITLE
Fix potential double-definition of WIN32_LEAN_AND_MEAN macro

### DIFF
--- a/src/regex.cpp
+++ b/src/regex.cpp
@@ -28,7 +28,9 @@
 #  include <malloc.h>
 #endif
 #ifdef BOOST_REGEX_HAS_MS_STACK_GUARD
-#define WIN32_LEAN_AND_MEAN
+#ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+#endif
 #ifndef NOMINMAX
 #  define NOMINMAX
 #endif

--- a/src/static_mutex.cpp
+++ b/src/static_mutex.cpp
@@ -28,7 +28,9 @@
 #ifndef NOMINMAX
 #  define NOMINMAX
 #endif
-#define WIN32_LEAN_AND_MEAN
+#ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #include <boost/static_assert.hpp>
 #endif

--- a/src/w32_regex_traits.cpp
+++ b/src/w32_regex_traits.cpp
@@ -23,7 +23,9 @@
 #include <boost/regex/regex_traits.hpp>
 #include <boost/regex/pattern_except.hpp>
 
-#define WIN32_LEAN_AND_MEAN
+#ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+#endif
 #ifndef NOMINMAX
 #  define NOMINMAX
 #endif


### PR DESCRIPTION
This prevents build errors if you're building these files using a build configuration that defines this macro on the command-line.