### PR TITLE
Add cygwin, cygwin64, and MSVC2017 strict builds to AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,13 +23,15 @@ environment:
     - ARGS: --toolset=msvc-14.0 address-model=32
     - ARGS: --toolset=msvc-12.0 address-model=64
     - ARGS: --toolset=msvc-14.0 address-model=64
-    - ARGS: --toolset=msvc-14.0 address-model=64 cxxflags=-std:c++latest
+    - ARGS: --toolset=msvc-14.0 address-model=64 cxxstd=latest
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       ARGS: --toolset=msvc-14.1 address-model=64
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       ARGS: --toolset=msvc-14.1 address-model=32
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      ARGS: --toolset=msvc-14.1 address-model=64 cxxflags=-std:c++latest
+      ARGS: --toolset=msvc-14.1 address-model=64 cxxstd=17
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARGS: --toolset=msvc-14.1 address-model=64 cxxstd=latest cxxflags=-permissive-
     - ARGS: --toolset=gcc address-model=64
       PATH: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%
     - ARGS: --toolset=gcc address-model=64 cxxflags=-std=gnu++1z
@@ -38,7 +40,10 @@ environment:
       PATH: C:\mingw-w64\i686-5.3.0-posix-dwarf-rt_v4-rev0\mingw32\bin;%PATH%
     - ARGS: --toolset=gcc address-model=32 linkflags=-Wl,-allow-multiple-definition
       PATH: C:\MinGW\bin;%PATH%
-
+    - ARGS: --toolset=gcc address-model=32 define=_POSIX_C_SOURCE=200112L threadapi=pthread link=static
+      PATH: C:\cygwin\bin;%PATH%
+    - ARGS: --toolset=gcc address-model=64 define=_POSIX_C_SOURCE=200112L define=__USE_ISOC99 threadapi=pthread link=static
+      PATH: C:\cygwin64\bin;%PATH%
 
 install:
   - cd ..


### PR DESCRIPTION
While this is related to #64 it simply restricts the linking to avoid that issue.  It does not resolve #64, but it does provide a solution for regex and cygwin builds.  I also updated the /std selectors to use Boost.Build since that support has been added.