### PR TITLE
[CMake] Add minimal cmake support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,13 @@ matrix:
       env: TOOLSET=gcc COMPILER=g++ CXXSTD=03
 
     - os: linux
-      env: TEST_CMAKE=true
+      env: TEST_CMAKE=true # unused - just for identification in travis ci gui
       script: 
+        - git submodule update --init tools/cmake
+        - git submodule update --init libs/typeof
+        - git submodule update --init libs/conversion
+        - git submodule update --init libs/function_types
+        - git submodule update --init libs/fusion
         - mkdir __build__
         - cd __build__
         - cmake .. -DBOOST_ENABLE_CMAKE=ON -DBOOST_REGEX_INCLUDE_EXAMPLES=ON 

--- a/.travis.yml
+++ b/.travis.yml
@@ -243,8 +243,9 @@ matrix:
       osx_image: xcode6.4
 
 install:
+  - BOOST_BRANCH=develop && [ "$TRAVIS_BRANCH" == "master" ] && BOOST_BRANCH=master || true
   - cd ..
-  - git clone -b $TRAVIS_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
+  - git clone -b $BOOST_BRANCH https://github.com/boostorg/boost.git boost-root
   - cd boost-root
   - git submodule update --init tools/build
   - git submodule update --init tools/boost_install

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,20 +28,31 @@ matrix:
 
   include:
     - os: linux
-      env: TOOLSET=gcc COMPILER=g++ CXXSTD=03
-
-    - os: linux
-      env: TEST_CMAKE=true # unused - just for identification in travis ci gui
-      script: 
+      env: TEST_CMAKE=true # variables unused - just for identification in travis ci gui
+      script:
         - git submodule update --init tools/cmake
-        - git submodule update --init libs/typeof
         - git submodule update --init libs/conversion
         - git submodule update --init libs/function_types
         - git submodule update --init libs/fusion
-        - mkdir __build__
-        - cd __build__
-        - cmake .. -DBOOST_ENABLE_CMAKE=ON -DBOOST_REGEX_INCLUDE_EXAMPLES=ON 
+        - git submodule update --init libs/typeof
+        - mkdir __build__ && cd __build__
+        - cmake .. -DBOOST_ENABLE_CMAKE=ON -DBOOST_REGEX_INCLUDE_EXAMPLES=ON
         - cmake --build .
+
+    - os: linux
+      env: TEST_CMAKE=true BUILD_SHARED_LIBS=On # variables unused - just for identification in travis ci gui
+      script:
+        - git submodule update --init tools/cmake
+        - git submodule update --init libs/conversion
+        - git submodule update --init libs/function_types
+        - git submodule update --init libs/fusion
+        - git submodule update --init libs/typeof
+        - mkdir __build__ && cd __build__
+        - cmake .. -DBUILD_SHARED_LIBS=ON -DBOOST_ENABLE_CMAKE=ON -DBOOST_REGEX_INCLUDE_EXAMPLES=ON
+        - cmake --build .
+
+    - os: linux
+      env: TOOLSET=gcc COMPILER=g++ CXXSTD=03
 
     - os: linux
       env: TOOLSET=gcc COMPILER=g++-4.7 CXXSTD=03,11

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,14 @@ matrix:
       env: TOOLSET=gcc COMPILER=g++ CXXSTD=03
 
     - os: linux
+      env: TEST_CMAKE=true
+      script: 
+        - mkdir __build__
+        - cd __build__
+        - cmake .. -DBOOST_ENABLE_CMAKE=ON -DBOOST_REGEX_INCLUDE_EXAMPLES=ON 
+        - cmake --build .
+
+    - os: linux
       env: TOOLSET=gcc COMPILER=g++-4.7 CXXSTD=03,11
       addons:
         apt:
@@ -241,6 +249,8 @@ matrix:
     - os: osx
       env: TOOLSET=clang COMPILER=clang++ CXXSTD=11
       osx_image: xcode6.4
+
+
 
 install:
   - BOOST_BRANCH=develop && [ "$TRAVIS_BRANCH" == "master" ] && BOOST_BRANCH=master || true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,26 @@ file( GLOB BOOST_REGEX_SRC ./src/*.cpp )
 add_library( boost_regex ${BOOST_REGEX_SRC} )
 add_library( Boost::regex ALIAS boost_regex )
 
-target_include_directories( boost_regex PUBLIC include )
-target_compile_definitions( boost_regex PUBLIC BOOST_REGEX_NO_LIB)
+# Currently, installation isn't supported directly,
+# but someone else might install this target from the parent
+# CMake script, so lets proactively differentiate between
+# the include directory during regular use (BUILD_INTERFACE)
+# and after installation
+target_include_directories( boost_regex
+    PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<INSTALL_INTERFACE:include>
+)
 
+target_compile_definitions( boost_regex
+    PUBLIC
+        # No need for autolink and we don't mangle library name anyway
+        BOOST_REGEX_NO_LIB
+        $<$<STREQUAL:$<TARGET_PROPERTY:boost_regex,TYPE>,SHARED_LIBRARY>:BOOST_REGEX_DYN_LINK=1>
+        $<$<STREQUAL:$<TARGET_PROPERTY:boost_regex,TYPE>,STATIC_LIBRARY>:BOOST_REGEX_STATIC_LINK=1>
+)
+
+# Specify dependencies (including header-only libraries)
 target_link_libraries( boost_regex
     PUBLIC
         Boost::assert

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,23 @@
-# Copyright 2018 Mike Dev
+# Copyright 2018-2019 Mike Dev
 # Distributed under the Boost Software License, Version 1.0.
-# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+# See accompanying file LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt
+#
+# NOTE: CMake support for Boost.Regex is currently experimental at best
+#       and the interface is likely to change in the future
 
-cmake_minimum_required(VERSION 3.5)
-project(BoostRegex LANGUAGES CXX)
+cmake_minimum_required( VERSION 3.5 )
+project( BoostRegex LANGUAGES CXX )
 
+option( BOOST_REGEX_INCLUDE_EXAMPLES "Also build (some) boost regex examples" OFF )
 
-file(GLOB BOOST_REGEX_SRC ./src/*.cpp)
+file( GLOB BOOST_REGEX_SRC ./src/*.cpp )
 
-add_library(boost_regex ${BOOST_REGEX_SRC})
-add_library(Boost::regex ALIAS boost_regex)
+add_library( boost_regex ${BOOST_REGEX_SRC} )
+add_library( Boost::regex ALIAS boost_regex )
 
-target_include_directories(boost_regex PUBLIC include)
+target_include_directories( boost_regex PUBLIC include )
 
-target_link_libraries(boost_regex
+target_link_libraries( boost_regex
     PUBLIC
         Boost::assert
         Boost::concept_check
@@ -29,3 +33,8 @@ target_link_libraries(boost_regex
         Boost::throw_exception
         Boost::type_traits
 )
+
+if( BOOST_REGEX_INCLUDE_EXAMPLES )
+    add_subdirectory( example/snippets )
+endif()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library( boost_regex ${BOOST_REGEX_SRC} )
 add_library( Boost::regex ALIAS boost_regex )
 
 target_include_directories( boost_regex PUBLIC include )
+target_compile_definitions( boost_regex PUBLIC BOOST_REGEX_NO_LIB)
 
 target_link_libraries( boost_regex
     PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Copyright 2018 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+cmake_minimum_required(VERSION 3.5)
+project(BoostRegex LANGUAGES CXX)
+
+
+file(GLOB BOOST_REGEX_SRC ./src/*.cpp)
+
+add_library(boost_regex ${BOOST_REGEX_SRC})
+add_library(Boost::regex ALIAS boost_regex)
+
+target_include_directories(boost_regex PUBLIC include)
+
+target_link_libraries(boost_regex
+    PUBLIC
+        Boost::assert
+        Boost::concept_check
+        Boost::config
+        Boost::container_hash
+        Boost::core
+        Boost::integer
+        Boost::iterator
+        Boost::mpl
+        Boost::predef
+        Boost::smart_ptr
+        Boost::static_assert
+        Boost::throw_exception
+        Boost::type_traits
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ cmake_minimum_required( VERSION 3.5 )
 project( BoostRegex LANGUAGES CXX )
 
 option( BOOST_REGEX_INCLUDE_EXAMPLES "Also build (some) boost regex examples" OFF )
+option( BOOST_REGEX_USE_ICU "Enable ICU support in boost regex" OFF )
 
 file( GLOB BOOST_REGEX_SRC ./src/*.cpp )
 
@@ -33,6 +34,19 @@ target_link_libraries( boost_regex
         Boost::throw_exception
         Boost::type_traits
 )
+
+if( BOOST_REGEX_USE_ICU )
+    if( NOT TARGET ICU::dt )
+        # components need to be listed explicitly
+        find_package( ICU COMPONENTS dt in uc REQUIRED )
+    endif()
+
+    target_link_libraries( boost_regex
+        PRIVATE
+            ICU::dt ICU::in ICU::uc
+    )
+    target_compile_definitions( boost_regex PRIVATE BOOST_HAS_ICU=1 )
+endif()
 
 if( BOOST_REGEX_INCLUDE_EXAMPLES )
     add_subdirectory( example/snippets )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,45 @@
 # NOTE: CMake support for Boost.Regex is currently experimental at best
 #       and the interface is likely to change in the future
 
+
+##### How-To:
+#
+# If you have a cmake project that wants to use and compile
+# boost_regex, as part of a single build system run, do the following:
+# 1) clone the boost project and all its sub-projects:
+#
+#   git clone --branch develop --depth 1 --recursive --shallow-submodules https://github.com/boostorg/boost.git boost-root
+#
+# 2) add to your cmake script:
+#
+#   add_subdirectory( <path-to-boost-root> [<build-dir-for-boost-libs>])
+#   target_link_libraries( <my-exec> PUBLIC Boost::regex)
+#
+# 3) run your cmake build as usual
+#
+# ## Explanation:
+#
+# Currently this file does not work standalone. It is expected to be
+# invoked from a parent script via add_subdirectory. That parent script
+# is responsible for providing targets for direct and indirect dependencies,
+# such as Boost::assert,  Boost::concept_check, e.g. by also adding those
+# libraries via add_submodule (order doesn't matter).
+# The parent script can be your own cmake script, but it is easier to just
+# use add the CMakeLists in the root of the boost super project, which
+# will in turn add all boost libraries usable with the add_subdirectory
+# Workflow.
+#
+# Note: You don't need to actually clone all boost libraries. E.g. look
+# into the travis ci file to see on which libraries boost_regex actually
+# depends or use boostdep https://github.com/boostorg/boostdep
+
+
+##### Current Limitations:
+#
+# - Doesn't compile or run tests
+# - Doesn't support installation
+#
+
 cmake_minimum_required( VERSION 3.5 )
 project( BoostRegex LANGUAGES CXX )
 
@@ -54,6 +93,8 @@ target_link_libraries( boost_regex
 )
 
 if( BOOST_REGEX_USE_ICU )
+    # ICU Targets could be provided by parent project,
+    # if not, look for them ourselves
     if( NOT TARGET ICU::dt )
         # components need to be listed explicitly
         find_package( ICU COMPONENTS dt in uc REQUIRED )

--- a/example/snippets/CMakeLists.txt
+++ b/example/snippets/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Copyright 2019 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt
+#
+# NOTE: CMake support for Boost.Regex is currently experimental at best
+#       and we are currently only building a few examples
+
+set(examples 
+    partial_regex_grep
+    partial_regex_iterate
+    partial_regex_match
+    regex_grep_example_1
+    regex_grep_example_2
+    regex_grep_example_3
+    regex_grep_example_4
+    regex_iterator_example
+    regex_match_example
+    regex_merge_example
+    regex_replace_example
+    regex_search_example
+    regex_split_example_1
+    regex_split_example_2
+    regex_token_iterator_eg_1
+    regex_token_iterator_eg_2
+)
+
+foreach( example IN LISTS examples )
+    add_executable( boost_regex_ex_${example} ${example}.cpp )
+    target_link_libraries( boost_regex_ex_${example} Boost::regex )
+endforeach()


### PR DESCRIPTION
Compiles Boost.Regex ~~(without ICU support)~~ and provides cmake target Boost::regex that other libraries can use in order to link to boost regex. 
No support for installation and unit tests

In order to test this PR, put a cmake file like this: https://github.com/Mike-Devel/BoostMinimalCMake_SupportRepo/blob/master/root_cmake_file/CMakeLists.txt into the boost root directory and then run the following commands from a separate build directory:

    - cmake -DBOOST_REGEX_INCLUDE_EXAMPLES=ON <path-to-boost-root>
    - cmake --build .

After this, the library will be in `<build-dir>libs/regex/` and the examples which are build (not all regex examples will be build by this PR) in  `<build-dir>/libs/regex/example/snippets`