### PR TITLE
Point for issues to Github instead of old Trac.

### DIFF
--- a/doc/history.qbk
+++ b/doc/history.qbk
@@ -8,12 +8,11 @@
 
 [section:history History]
 
-New issues should be submitted at [@http://svn.boost.org svn.boost.org] - don't forget to include your
-email address in the ticket!
+New issues should be submitted at [@https://github.com/boostorg/regex/issues https://github.com/boostorg/regex/issues]
 
-Currently open issues can be viewed [@https://svn.boost.org/trac/boost/query?status=assigned&status=new&status=reopened&component=regex&order=priority&col=id&col=summary&col=status&col=type&col=milestone&col=component here].
+Currently open issues can be viewed [@https://github.com/boostorg/regex/issues?q=is%3Aopen+is%3Aissue here].
 
-All issues including closed ones can be viewed [@https://svn.boost.org/trac/boost/query?status=assigned&status=closed&status=new&status=reopened&component=regex&order=priority&col=id&col=summary&col=status&col=type&col=milestone&col=component here].
+All issues including closed ones can be viewed [@https://github.com/boostorg/regex/issues?q=is%3Aissue+is%3Aclosed here].
 
 [h4 Boost.Regex-5.1.3 (Boost-1.64.0)]
 


### PR DESCRIPTION
The documentation contains links to the obsolete *Trac* issue tracker.  
This PR fixes that and points instead to the *Github* issue tracker for *Boost.Regex*.