### PR TITLE
Avoid generating pointers in writeable data section.

### DIFF
--- a/include/boost/regex/v4/basic_regex_parser.hpp
+++ b/include/boost/regex/v4/basic_regex_parser.hpp
@@ -859,7 +859,7 @@ escape_type_class_jump:
       {
          bool have_brace = false;
          bool negative = false;
-         static const char* incomplete_message = "Incomplete \\g escape found.";
+         static const char incomplete_message[] = "Incomplete \\g escape found.";
          if(++m_position == m_end)
          {
             fail(regex_constants::error_escape, m_position - m_base, incomplete_message);
@@ -1133,7 +1133,7 @@ bool basic_regex_parser<charT, traits>::parse_repeat(std::size_t low, std::size_
 template <class charT, class traits>
 bool basic_regex_parser<charT, traits>::parse_repeat_range(bool isbasic)
 {
-   static const char* incomplete_message = "Missing } in quantified repetition.";
+   static const char incomplete_message[] = "Missing } in quantified repetition.";
    //
    // parse a repeat-range:
    //
@@ -1339,7 +1339,7 @@ bool basic_regex_parser<charT, traits>::parse_alt()
 template <class charT, class traits>
 bool basic_regex_parser<charT, traits>::parse_set()
 {
-   static const char* incomplete_message = "Character set declaration starting with [ terminated prematurely - either no ] was found or the set had no content.";
+   static const char incomplete_message[] = "Character set declaration starting with [ terminated prematurely - either no ] was found or the set had no content.";
    ++m_position;
    if(m_position == m_end)
    {
@@ -1431,7 +1431,7 @@ bool basic_regex_parser<charT, traits>::parse_set()
 template <class charT, class traits>
 bool basic_regex_parser<charT, traits>::parse_inner_set(basic_char_set<charT, traits>& char_set)
 {
-   static const char* incomplete_message = "Character class declaration starting with [ terminated prematurely - either no ] was found or the set had no content.";
+   static const char incomplete_message[] = "Character class declaration starting with [ terminated prematurely - either no ] was found or the set had no content.";
    //
    // we have either a character class [:name:]
    // a collating element [.name.]

--- a/include/boost/regex/v4/regex_traits_defaults.hpp
+++ b/include/boost/regex/v4/regex_traits_defaults.hpp
@@ -208,8 +208,8 @@ int get_default_class_id(const charT* p1, const charT* p2)
       {data+63, data+67,}, // word
       {data+67, data+73,}, // xdigit
    };
-   static const character_pointer_range<charT>* ranges_begin = ranges;
-   static const character_pointer_range<charT>* ranges_end = ranges + (sizeof(ranges)/sizeof(ranges[0]));
+   const character_pointer_range<charT>* ranges_begin = ranges;
+   const character_pointer_range<charT>* ranges_end = ranges + (sizeof(ranges)/sizeof(ranges[0]));
 
    character_pointer_range<charT> t = { p1, p2, };
    const character_pointer_range<charT>* p = std::lower_bound(ranges_begin, ranges_end, t);

--- a/src/icu.cpp
+++ b/src/icu.cpp
@@ -354,8 +354,8 @@ icu_regex_traits::char_class_type icu_regex_traits::lookup_icu_mask(const ::UCha
    };
 
 
-   static const BOOST_REGEX_DETAIL_NS::character_pointer_range< ::UChar32>* ranges_begin = range_data;
-   static const BOOST_REGEX_DETAIL_NS::character_pointer_range< ::UChar32>* ranges_end = range_data + (sizeof(range_data)/sizeof(range_data[0]));
+   const BOOST_REGEX_DETAIL_NS::character_pointer_range< ::UChar32>* ranges_begin = range_data;
+   const BOOST_REGEX_DETAIL_NS::character_pointer_range< ::UChar32>* ranges_end = range_data + (sizeof(range_data)/sizeof(range_data[0]));
    
    BOOST_REGEX_DETAIL_NS::character_pointer_range< ::UChar32> t = { p1, p2, };
    const BOOST_REGEX_DETAIL_NS::character_pointer_range< ::UChar32>* p = std::lower_bound(ranges_begin, ranges_end, t);

--- a/src/regex_traits_defaults.cpp
+++ b/src/regex_traits_defaults.cpp
@@ -193,7 +193,7 @@ BOOST_REGEX_DECL bool BOOST_REGEX_CALL is_combining_implementation(boost::uint_l
 //
 // these are the POSIX collating names:
 //
-BOOST_REGEX_DECL const char* def_coll_names[] = {
+BOOST_REGEX_DECL extern const char* const def_coll_names[] = {
 "NUL", "SOH", "STX", "ETX", "EOT", "ENQ", "ACK", "alert", "backspace", "tab", "newline", 
 "vertical-tab", "form-feed", "carriage-return", "SO", "SI", "DLE", "DC1", "DC2", "DC3", "DC4", "NAK", 
 "SYN", "ETB", "CAN", "EM", "SUB", "ESC", "IS4", "IS3", "IS2", "IS1", "space", "exclamation-mark", 
@@ -214,7 +214,7 @@ BOOST_REGEX_DECL const char* def_coll_names[] = {
 // little more - but this will have to do for
 // now:
 
-BOOST_REGEX_DECL const char* def_multi_coll[] = {
+BOOST_REGEX_DECL extern const char* const def_multi_coll[] = {
    "ae",
    "Ae",
    "AE",


### PR DESCRIPTION
They increase memory consumption and make exploits
easier and are completely unnecessary.
Avoid them by either avoiding the pointer indirection
completely by using char arrays for strings instead
of char pointers, convert "static" pointer variables
to simple local variables, or mark the array of
pointers as const instead of just the things pointed to.