### PR TITLE
regex_traits_defaults: Do not export arrays only used in same compila…

### DIFF
--- a/src/regex_traits_defaults.cpp
+++ b/src/regex_traits_defaults.cpp
@@ -193,7 +193,7 @@ BOOST_REGEX_DECL bool BOOST_REGEX_CALL is_combining_implementation(boost::uint_l
 //
 // these are the POSIX collating names:
 //
-BOOST_REGEX_DECL const char* def_coll_names[] = {
+static const char* def_coll_names[] = {
 "NUL", "SOH", "STX", "ETX", "EOT", "ENQ", "ACK", "alert", "backspace", "tab", "newline", 
 "vertical-tab", "form-feed", "carriage-return", "SO", "SI", "DLE", "DC1", "DC2", "DC3", "DC4", "NAK", 
 "SYN", "ETB", "CAN", "EM", "SUB", "ESC", "IS4", "IS3", "IS2", "IS1", "space", "exclamation-mark", 
@@ -214,7 +214,7 @@ BOOST_REGEX_DECL const char* def_coll_names[] = {
 // little more - but this will have to do for
 // now:
 
-BOOST_REGEX_DECL const char* def_multi_coll[] = {
+static const char* def_multi_coll[] = {
    "ae",
    "Ae",
    "AE",


### PR DESCRIPTION
…tion unit.

Exporting variables is unreliable on some platforms including Windows,
and it seems can cause compilation errors in some cases.
Also symbols should not be exported unnecessarily purely on principle.
It would even be possible to move the arrays into the function, but
as they are a bit large that seems to be worse for readability.