### PR TITLE
Fix clang -Wdeprecated-copy warning in basic_regex_creator.hpp

### DIFF
--- a/include/boost/regex/v4/basic_regex_creator.hpp
+++ b/include/boost/regex/v4/basic_regex_creator.hpp
@@ -52,6 +52,9 @@ struct digraph : public std::pair<charT, charT>
    digraph(charT c1, charT c2) : std::pair<charT, charT>(c1, c2)
    {}
    digraph(const digraph<charT>& d) : std::pair<charT, charT>(d.first, d.second){}
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+   digraph<charT>& operator=(const digraph<charT>&) = default;
+#endif
    template <class Seq>
    digraph(const Seq& s) : std::pair<charT, charT>()
    {


### PR DESCRIPTION
/data/mwrep/res/osp/Boost/19-0-0-18/include/boost/regex/v4/basic_regex_creator.hpp:52:4: error: definition of implicit copy assignment operator for 'digraph<char>' is deprecated because it has a user-declared copy constructor [-Werror,-Wdeprecated-copy]
   digraph(const digraph<charT>& d) : std::pair<charT, charT>(d.first, d.second){}
   ^
/data/mwrep/res/osp/Boost/19-0-0-18/include/boost/regex/v4/basic_regex_parser.hpp:1660:17: note: in implicit copy assignment operator for 'boost::re_detail_107000::digraph<char>' first required here
         result = *m_position++;