### PR TITLE
Use BOOST_OVERRIDE

### DIFF
--- a/include/boost/regex/icu.hpp
+++ b/include/boost/regex/icu.hpp
@@ -894,7 +894,7 @@ OutputIterator do_regex_replace(OutputIterator out,
       {
          if(!(flags & regex_constants::format_no_copy))
             out = BOOST_REGEX_DETAIL_NS::copy(i->prefix().first, i->prefix().second, out); 
-         if(f.size())
+         if(!f.empty())
             out = ::boost::BOOST_REGEX_DETAIL_NS::regex_format_imp(out, *i, &*f.begin(), &*f.begin() + f.size(), flags, e.get_traits());
          else
             out = ::boost::BOOST_REGEX_DETAIL_NS::regex_format_imp(out, *i, static_cast<UChar32 const*>(0), static_cast<UChar32 const*>(0), flags, e.get_traits());

--- a/include/boost/regex/pattern_except.hpp
+++ b/include/boost/regex/pattern_except.hpp
@@ -23,8 +23,8 @@
 #include <boost/regex/config.hpp>
 #endif
 
-#include <stdexcept>
 #include <cstddef>
+#include <stdexcept>
 #include <boost/regex/v4/error_type.hpp>
 
 namespace boost{
@@ -52,7 +52,7 @@ class BOOST_REGEX_DECL regex_error : public std::runtime_error
 public:
    explicit regex_error(const std::string& s, regex_constants::error_type err = regex_constants::error_unknown, std::ptrdiff_t pos = 0);
    explicit regex_error(regex_constants::error_type err);
-   ~regex_error() BOOST_NOEXCEPT_OR_NOTHROW;
+   ~regex_error() BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE;
    regex_constants::error_type code()const
    { return m_error_code; }
    std::ptrdiff_t position()const
@@ -98,6 +98,3 @@ void raise_error(const traits& t, regex_constants::error_type code)
 } // namespace boost
 
 #endif
-
-
-

--- a/include/boost/regex/v4/basic_regex.hpp
+++ b/include/boost/regex/v4/basic_regex.hpp
@@ -416,7 +416,7 @@ public:
    {
       typedef typename traits::string_type seq_type;
       seq_type a(arg_first, arg_last);
-      if(a.size())
+      if(!a.empty())
          assign(static_cast<const charT*>(&*a.begin()), static_cast<const charT*>(&*a.begin() + a.size()), f);
       else
          assign(static_cast<const charT*>(0), static_cast<const charT*>(0), f);
@@ -657,7 +657,7 @@ private:
 //
 // out of line members;
 // these are the only members that mutate the basic_regex object,
-// and are designed to provide the strong exception guarentee
+// and are designed to provide the strong exception guarantee
 // (in the event of a throw, the state of the object remains unchanged).
 //
 template <class charT, class traits>
@@ -795,4 +795,3 @@ public:
 #endif
 
 #endif
-

--- a/include/boost/regex/v4/basic_regex_creator.hpp
+++ b/include/boost/regex/v4/basic_regex_creator.hpp
@@ -243,7 +243,7 @@ protected:
    bool                          m_has_backrefs;       // true if there are actually any backrefs
    indexed_bit_flag              m_backrefs;           // bitmask of permitted backrefs
    boost::uintmax_t              m_bad_repeats;        // bitmask of repeats we can't deduce a startmap for;
-   bool                          m_has_recursions;     // set when we have recursive expresisons to fixup
+   bool                          m_has_recursions;     // set when we have recursive expressions to fixup
    std::vector<unsigned char>    m_recursion_checks;   // notes which recursions we've followed while analysing this expression
    typename traits::char_class_type m_word_mask;       // mask used to determine if a character is a word character
    typename traits::char_class_type m_mask_space;      // mask used to determine if a character is a word character
@@ -447,9 +447,9 @@ re_syntax_base* basic_regex_creator<charT, traits>::append_set(
          charT a2[3] = { c2.first, c2.second, charT(0), };
          s1 = this->m_traits.transform(a1, (a1[1] ? a1+2 : a1+1));
          s2 = this->m_traits.transform(a2, (a2[1] ? a2+2 : a2+1));
-         if(s1.size() == 0)
+         if(s1.empty())
             s1 = string_type(1, charT(0));
-         if(s2.size() == 0)
+         if(s2.empty())
             s2 = string_type(1, charT(0));
       }
       else
@@ -951,7 +951,7 @@ void basic_regex_creator<charT, traits>::create_startmaps(re_syntax_base* state)
    }
 
    // now work through our list, building all the maps as we go:
-   while(v.size())
+   while(!v.empty())
    {
       // Initialize m_recursion_checks if we need it:
       if(m_has_recursions)
@@ -1516,7 +1516,7 @@ template <class charT, class traits>
 void basic_regex_creator<charT, traits>::probe_leading_repeat(re_syntax_base* state)
 {
    // enumerate our states, and see if we have a leading repeat 
-   // for which failed search restarts can be optimised;
+   // for which failed search restarts can be optimized;
    do
    {
       switch(state->type)
@@ -1573,7 +1573,6 @@ void basic_regex_creator<charT, traits>::probe_leading_repeat(re_syntax_base* st
    }while(state);
 }
 
-
 } // namespace BOOST_REGEX_DETAIL_NS
 
 } // namespace boost
@@ -1594,4 +1593,3 @@ void basic_regex_creator<charT, traits>::probe_leading_repeat(re_syntax_base* st
 #endif
 
 #endif
-

--- a/include/boost/regex/v4/basic_regex_parser.hpp
+++ b/include/boost/regex/v4/basic_regex_parser.hpp
@@ -172,7 +172,7 @@ void basic_regex_parser<charT, traits>::parse(const charT* p1, const charT* p2, 
       m_parser_proc = &basic_regex_parser<charT, traits>::parse_literal;
       break;
    default:
-      // Ooops, someone has managed to set more than one of the main option flags, 
+      // Oops, someone has managed to set more than one of the main option flags, 
       // so this must be an error:
       fail(regex_constants::error_unknown, 0, "An invalid combination of regular expression syntax flags was used.");
       return;
@@ -981,7 +981,7 @@ template <class charT, class traits>
 bool basic_regex_parser<charT, traits>::parse_repeat(std::size_t low, std::size_t high)
 {
    bool greedy = true;
-   bool pocessive = false;
+   bool possessive = false;
    std::size_t insert_point;
    // 
    // when we get to here we may have a non-greedy ? mark still to come:
@@ -1005,12 +1005,12 @@ bool basic_regex_parser<charT, traits>::parse_repeat(std::size_t low, std::size_
          greedy = false;
          ++m_position;
       }
-      // for perl regexes only check for pocessive ++ repeats.
+      // for perl regexes only check for possessive ++ repeats.
       if((m_position != m_end)
          && (0 == (this->flags() & regbase::main_option_type)) 
          && (this->m_traits.syntax_type(*m_position) == regex_constants::syntax_plus))
       {
-         pocessive = true;
+         possessive = true;
          ++m_position;
       }
    }
@@ -1082,10 +1082,10 @@ bool basic_regex_parser<charT, traits>::parse_repeat(std::size_t low, std::size_
    rep = static_cast<re_repeat*>(this->getaddress(rep_off));
    rep->alt.i = this->m_pdata->m_data.size() - rep_off;
    //
-   // If the repeat is pocessive then bracket the repeat with a (?>...)
+   // If the repeat is possessive then bracket the repeat with a (?>...)
    // independent sub-expression construct:
    //
-   if(pocessive)
+   if(possessive)
    {
       if(m_position != m_end)
       {
@@ -1542,7 +1542,7 @@ bool basic_regex_parser<charT, traits>::parse_inner_set(basic_char_set<charT, tr
          fail(regex_constants::error_ctype, name_first - m_base);
          return false;
       }
-      if(negated == false)
+      if(!negated)
          char_set.add_class(m);
       else
          char_set.add_negated_class(m);
@@ -1580,7 +1580,7 @@ bool basic_regex_parser<charT, traits>::parse_inner_set(basic_char_set<charT, tr
          return false;
       }
       string_type m = this->m_traits.lookup_collatename(name_first, name_last);
-      if((0 == m.size()) || (m.size() > 2))
+      if(m.empty() || (m.size() > 2))
       {
          fail(regex_constants::error_collate, name_first - m_base);
          return false;
@@ -3112,7 +3112,7 @@ bool basic_regex_parser<charT, traits>::unwind_alts(std::ptrdiff_t last_paren_st
    // alternative then that's an error:
    //
    if((this->m_alt_insert_point == static_cast<std::ptrdiff_t>(this->m_pdata->m_data.size()))
-      && m_alt_jumps.size() && (m_alt_jumps.back() > last_paren_start)
+      && (!m_alt_jumps.empty()) && (m_alt_jumps.back() > last_paren_start)
       &&
       !(
          ((this->flags() & regbase::main_option_type) == regbase::perl_syntax_group)
@@ -3127,7 +3127,7 @@ bool basic_regex_parser<charT, traits>::unwind_alts(std::ptrdiff_t last_paren_st
    // 
    // Fix up our alternatives:
    //
-   while(m_alt_jumps.size() && (m_alt_jumps.back() > last_paren_start))
+   while((!m_alt_jumps.empty()) && (m_alt_jumps.back() > last_paren_start))
    {
       //
       // fix up the jump to point to the end of the states

--- a/include/boost/regex/v4/cpp_regex_traits.hpp
+++ b/include/boost/regex/v4/cpp_regex_traits.hpp
@@ -41,9 +41,9 @@
 #include <boost/regex/pending/object_cache.hpp>
 #endif
 
-#include <istream>
-#include <ios>
 #include <climits>
+#include <ios>
+#include <istream>
 
 #ifdef BOOST_MSVC
 #pragma warning(push)
@@ -89,9 +89,9 @@ public:
    parser_buf() : base_type() { setbuf(0, 0); }
    const charT* getnext() { return this->gptr(); }
 protected:
-   std::basic_streambuf<charT, traits>* setbuf(char_type* s, streamsize n);
-   typename parser_buf<charT, traits>::pos_type seekpos(pos_type sp, ::std::ios_base::openmode which);
-   typename parser_buf<charT, traits>::pos_type seekoff(off_type off, ::std::ios_base::seekdir way, ::std::ios_base::openmode which);
+   std::basic_streambuf<charT, traits>* setbuf(char_type* s, streamsize n) BOOST_OVERRIDE;
+   typename parser_buf<charT, traits>::pos_type seekpos(pos_type sp, ::std::ios_base::openmode which) BOOST_OVERRIDE;
+   typename parser_buf<charT, traits>::pos_type seekoff(off_type off, ::std::ios_base::seekdir way, ::std::ios_base::openmode which) BOOST_OVERRIDE;
 private:
    parser_buf& operator=(const parser_buf&);
    parser_buf(const parser_buf&);
@@ -225,7 +225,7 @@ std::locale cpp_regex_traits_base<charT>::imbue(const std::locale& l)
 
 //
 // class cpp_regex_traits_char_layer:
-// implements methods that require specialisation for narrow characters:
+// implements methods that require specialization for narrow characters:
 //
 template <class charT>
 class cpp_regex_traits_char_layer : public cpp_regex_traits_base<charT>
@@ -281,7 +281,7 @@ void cpp_regex_traits_char_layer<charT>::init()
    typename std::messages<charT>::catalog cat = reinterpret_cast<std::messages<char>::catalog>(-1);
 #endif
    std::string cat_name(cpp_regex_traits<charT>::get_catalog_name());
-   if(cat_name.size() && (this->m_pmessages != 0))
+   if((!cat_name.empty()) && (this->m_pmessages != 0))
    {
       cat = this->m_pmessages->open(
          cat_name, 
@@ -352,7 +352,7 @@ typename cpp_regex_traits_char_layer<charT>::string_type
 }
 
 //
-// specialised version for narrow characters:
+// specialized version for narrow characters:
 //
 template <>
 class BOOST_REGEX_DECL cpp_regex_traits_char_layer<char> : public cpp_regex_traits_base<char>
@@ -566,7 +566,7 @@ typename cpp_regex_traits_implementation<charT>::string_type
 #ifndef BOOST_NO_EXCEPTIONS
    }catch(...){}
 #endif
-   while(result.size() && (charT(0) == *result.rbegin()))
+   while((!result.empty()) && (charT(0) == *result.rbegin()))
       result.erase(result.size() - 1);
    if(result.empty())
    {
@@ -621,7 +621,7 @@ typename cpp_regex_traits_implementation<charT>::string_type
 #else
       //
       // some implementations (Dinkumware) append unnecessary trailing \0's:
-      while(result.size() && (charT(0) == *result.rbegin()))
+      while((!result.empty()) && (charT(0) == *result.rbegin()))
          result.erase(result.size() - 1);
 #endif
       //
@@ -662,7 +662,7 @@ typename cpp_regex_traits_implementation<charT>::string_type
    cpp_regex_traits_implementation<charT>::lookup_collatename(const charT* p1, const charT* p2) const
 {
    typedef typename std::map<string_type, string_type>::const_iterator iter_type;
-   if(m_custom_collate_names.size())
+   if(!m_custom_collate_names.empty())
    {
       iter_type pos = m_custom_collate_names.find(string_type(p1, p2));
       if(pos != m_custom_collate_names.end())
@@ -680,10 +680,10 @@ typename cpp_regex_traits_implementation<charT>::string_type
    name = lookup_default_collate_name(name);
 #if !defined(BOOST_NO_TEMPLATED_ITERATOR_CONSTRUCTORS)\
                && !BOOST_WORKAROUND(__BORLANDC__, <= 0x0551)
-   if(name.size())
+   if(!name.empty())
       return string_type(name.begin(), name.end());
 #else
-   if(name.size())
+   if(!name.empty())
    {
       string_type result;
       typedef std::string::const_iterator iter;
@@ -709,7 +709,7 @@ void cpp_regex_traits_implementation<charT>::init()
    typename std::messages<charT>::catalog cat = reinterpret_cast<std::messages<char>::catalog>(-1);
 #endif
    std::string cat_name(cpp_regex_traits<charT>::get_catalog_name());
-   if(cat_name.size() && (this->m_pmessages != 0))
+   if((!cat_name.empty()) && (this->m_pmessages != 0))
    {
       cat = this->m_pmessages->open(
          cat_name, 
@@ -796,7 +796,7 @@ void cpp_regex_traits_implementation<charT>::init()
       for(unsigned int j = 0; j <= 13; ++j)
       {
          string_type s(this->m_pmessages->get(cat, 0, j+300, null_string));
-         if(s.size())
+         if(!s.empty())
             this->m_custom_class_names[s] = masks[j];
       }
    }
@@ -864,7 +864,7 @@ typename cpp_regex_traits_implementation<charT>::char_class_type
       ::boost::BOOST_REGEX_DETAIL_NS::char_class_xdigit,
    };
 #endif
-   if(m_custom_class_names.size())
+   if(!m_custom_class_names.empty())
    {
       typedef typename std::map<std::basic_string<charT>, char_class_type>::const_iterator map_iter;
       map_iter pos = m_custom_class_names.find(string_type(p1, p2));
@@ -1129,7 +1129,6 @@ static_mutex& cpp_regex_traits<charT>::get_mutex_inst()
 }
 #endif
 
-
 } // boost
 
 #ifdef BOOST_MSVC
@@ -1150,5 +1149,3 @@ static_mutex& cpp_regex_traits<charT>::get_mutex_inst()
 #endif
 
 #endif
-
-

--- a/include/boost/regex/v4/perl_matcher.hpp
+++ b/include/boost/regex/v4/perl_matcher.hpp
@@ -88,7 +88,7 @@ inline bool can_start(unsigned int c, const unsigned char* map, unsigned char ma
 
 //
 // Unfortunately Rogue Waves standard library appears to have a bug
-// in std::basic_string::compare that results in eroneous answers
+// in std::basic_string::compare that results in erroneous answers
 // in some cases (tested with Borland C++ 5.1, Rogue Wave lib version
 // 0x020101) the test case was:
 // {39135,0} < {0xff,0}
@@ -375,7 +375,7 @@ class perl_matcher
 public:
    typedef typename traits::char_type char_type;
    typedef perl_matcher<BidiIterator, Allocator, traits> self_type;
-   typedef bool (self_type::*matcher_proc_type)(void);
+   typedef bool (self_type::*matcher_proc_type)();
    typedef std::size_t traits_size_type;
    typedef typename is_byte<char_type>::width_type width_type;
    typedef typename regex_iterator_traits<BidiIterator>::difference_type difference_type;
@@ -633,4 +633,3 @@ private:
 #include <boost/regex/v4/perl_matcher_common.hpp>
 
 #endif
-

--- a/include/boost/regex/v4/perl_matcher_non_recursive.hpp
+++ b/include/boost/regex/v4/perl_matcher_non_recursive.hpp
@@ -217,7 +217,7 @@ bool perl_matcher<BidiIterator, Allocator, traits>::match_all_states()
             bool successful_unwind = unwind(false);
             if((m_match_flags & match_partial) && (position == last) && (position != search_base))
                m_has_partial_match = true;
-            if(false == successful_unwind)
+            if(!successful_unwind)
                return m_recursive_result;
          }
       }
@@ -348,7 +348,7 @@ inline void perl_matcher<BidiIterator, Allocator, traits>::push_repeater_count(i
       pmp = static_cast<saved_repeater<BidiIterator>*>(m_backup_state);
       --pmp;
    }
-   (void) new (pmp)saved_repeater<BidiIterator>(i, s, position, this->recursion_stack.size() ? this->recursion_stack.back().idx : (INT_MIN + 3));
+   (void) new (pmp)saved_repeater<BidiIterator>(i, s, position, this->recursion_stack.empty() ? (INT_MIN + 3) : this->recursion_stack.back().idx);
    m_backup_state = pmp;
 }
 
@@ -705,7 +705,7 @@ bool perl_matcher<BidiIterator, Allocator, traits>::match_dot_repeat_slow()
    std::size_t count = 0;
    const re_repeat* rep = static_cast<const re_repeat*>(pstate);
    re_syntax_base* psingle = rep->next.p;
-   // match compulsary repeats first:
+   // match compulsory repeats first:
    while(count < rep->min)
    {
       pstate = psingle;
@@ -1224,7 +1224,7 @@ bool perl_matcher<BidiIterator, Allocator, traits>::skip_until_paren(int index, 
 
 /****************************************************************************
 
-Unwind and associated proceedures follow, these perform what normal stack
+Unwind and associated procedures follow, these perform what normal stack
 unwinding does in the recursive implementation.
 
 ****************************************************************************/
@@ -1296,7 +1296,7 @@ bool perl_matcher<BidiIterator, Allocator, traits>::unwind_paren(bool have_match
 {
    saved_matched_paren<BidiIterator>* pmp = static_cast<saved_matched_paren<BidiIterator>*>(m_backup_state);
    // restore previous values if no match was found:
-   if(have_match == false)
+   if(!have_match)
    {
       m_presult->set_first(pmp->sub.first, pmp->index, pmp->index == 0);
       m_presult->set_second(pmp->sub.second, pmp->index, pmp->sub.matched, pmp->index == 0);
@@ -1944,5 +1944,3 @@ inline void perl_matcher<BidiIterator, Allocator, traits>::push_parenthesis_push
 #endif
 
 #endif
-
-

--- a/include/boost/regex/v4/protected_call.hpp
+++ b/include/boost/regex/v4/protected_call.hpp
@@ -20,6 +20,8 @@
 #ifndef BOOST_REGEX_V4_PROTECTED_CALL_HPP
 #define BOOST_REGEX_V4_PROTECTED_CALL_HPP
 
+#include <boost/config.hpp>
+
 #ifdef BOOST_MSVC
 #pragma warning(push)
 #pragma warning(disable: 4103)
@@ -53,7 +55,7 @@ public:
    concrete_protected_call(T* o, proc_type p)
       : obj(o), proc(p) {}
 private:
-   virtual bool call()const;
+   bool call()const BOOST_OVERRIDE;
    T* obj;
    proc_type proc;
 };

--- a/src/c_regex_traits.cpp
+++ b/src/c_regex_traits.cpp
@@ -16,7 +16,6 @@
   *   DESCRIPTION: Implements out of line c_regex_traits<char> members
   */
 
-
 #define BOOST_REGEX_SOURCE
 
 #include <boost/config.hpp>
@@ -105,7 +104,7 @@ c_regex_traits<char>::string_type BOOST_REGEX_CALL c_regex_traits<char>::transfo
    case ::boost::BOOST_REGEX_DETAIL_NS::sort_delim:
          // get a regular sort key, and then truncate everything after the delim:
          result = transform(p1, p2);
-         if(result.size() && (result[0] == s_delim))
+         if((!result.empty()) && (result[0] == s_delim))
             break;
          std::size_t i;
          for(i = 0; i < result.size(); ++i)

--- a/src/cpp_regex_traits.cpp
+++ b/src/cpp_regex_traits.cpp
@@ -42,7 +42,7 @@ void cpp_regex_traits_char_layer<char>::init()
    std::messages<char>::catalog cat = reinterpret_cast<std::messages<char>::catalog>(-1);
 #endif
    std::string cat_name(cpp_regex_traits<char>::get_catalog_name());
-   if(cat_name.size() && (m_pmessages != 0))
+   if((!cat_name.empty()) && (m_pmessages != 0))
    {
       cat = this->m_pmessages->open(
          cat_name, 
@@ -114,4 +114,3 @@ void cpp_regex_traits_char_layer<char>::init()
 } // BOOST_REGEX_DETAIL_NS
 } // boost
 #endif
-

--- a/src/cregex.cpp
+++ b/src/cregex.cpp
@@ -22,11 +22,11 @@
 #include <boost/regex.hpp>
 #include <boost/cregex.hpp>
 #if !defined(BOOST_NO_STD_STRING)
-#include <map>
+#include <cstdio>
 #include <list>
+#include <map>
 #include <boost/regex/v4/fileiter.hpp>
 typedef boost::match_flag_type match_flag_type;
-#include <cstdio>
 
 #ifdef BOOST_MSVC
 #pragma warning(disable:4309)
@@ -417,7 +417,7 @@ unsigned int RegEx::GrepFiles(GrepFileCallback cb, const char* files, bool recur
       result += r;
       ++start;
       pdata->clean();
-      if(pred.ok == false)
+      if(!pred.ok)
          return result;
    }
 
@@ -443,7 +443,7 @@ unsigned int RegEx::FindFiles(FindFilesCallback cb, const char* files, bool recu
       if(regex_search(map.begin(), map.end(), pdata->fm, pdata->e, flags))
       {
          ++result;
-         if(false == cb((*start).c_str()))
+         if(!cb((*start).c_str()))
             return result;
       }
       //pdata->update();
@@ -649,19 +649,3 @@ basic_string<wchar_t>::replace<const wchar_t*>(wchar_t* f1, wchar_t* f2, const w
 #endif
 
 #endif
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/icu.cpp
+++ b/src/icu.cpp
@@ -44,14 +44,14 @@ icu_regex_traits_implementation::string_type icu_regex_traits_implementation::do
 #endif
    ::uint8_t result[100];
    ::int32_t len;
-   if(t.size())
+   if(!t.empty())
       len = pcoll->getSortKey(&*t.begin(), static_cast< ::int32_t>(t.size()), result, sizeof(result));
    else
       len = pcoll->getSortKey(static_cast<UChar const*>(0), static_cast< ::int32_t>(0), result, sizeof(result));
    if(std::size_t(len) > sizeof(result))
    {
       scoped_array< ::uint8_t> presult(new ::uint8_t[len+1]);
-      if(t.size())
+      if(!t.empty())
          len = pcoll->getSortKey(&*t.begin(), static_cast< ::int32_t>(t.size()), presult.get(), len+1);
       else
          len = pcoll->getSortKey(static_cast<UChar const*>(0), static_cast< ::int32_t>(0), presult.get(), len+1);
@@ -414,11 +414,11 @@ icu_regex_traits::char_class_type icu_regex_traits::lookup_classname(const char_
             ++i;
          }
       }
-      if(s.size())
+      if(!s.empty())
          idx = ::boost::BOOST_REGEX_DETAIL_NS::get_default_class_id(&*s.begin(), &*s.begin() + s.size());
       if(idx >= 0)
          return masks[idx+1];
-      if(s.size())
+      if(!s.empty())
          result = lookup_icu_mask(&*s.begin(), &*s.begin() + s.size());
       if(result != 0)
          return result;

--- a/src/posix_api.cpp
+++ b/src/posix_api.cpp
@@ -19,9 +19,9 @@
 #define BOOST_REGEX_SOURCE
 
 #include <boost/config.hpp>
-#include <cstdio>
 #include <boost/regex.hpp>
 #include <boost/cregex.hpp>
+#include <cstdio>
 
 #if defined(BOOST_NO_STDC_NAMESPACE)
 namespace std{
@@ -269,8 +269,8 @@ BOOST_REGEX_DECL int BOOST_REGEX_CCALL regexecA(const regex_tA* expression, cons
       std::size_t i;
       for(i = 0; (i < n) && (i < expression->re_nsub + 1); ++i)
       {
-         array[i].rm_so = (m[i].matched == false) ? -1 : (m[i].first - buf);
-         array[i].rm_eo = (m[i].matched == false) ? -1 : (m[i].second - buf);
+         array[i].rm_so = m[i].matched ? (m[i].first - buf) : -1;
+         array[i].rm_eo = m[i].matched ? (m[i].second - buf) : -1;
       }
       // and set anything else to -1:
       for(i = expression->re_nsub + 1; i < n; ++i)
@@ -296,7 +296,3 @@ BOOST_REGEX_DECL void BOOST_REGEX_CCALL regfreeA(regex_tA* expression)
 }
 
 } // namespace boost
-
-
-
-

--- a/src/wc_regex_traits.cpp
+++ b/src/wc_regex_traits.cpp
@@ -145,7 +145,7 @@ c_regex_traits<wchar_t>::string_type BOOST_REGEX_CALL c_regex_traits<wchar_t>::t
    case ::boost::BOOST_REGEX_DETAIL_NS::sort_delim:
          // get a regular sort key, and then truncate everything after the delim:
          result = c_regex_traits<wchar_t>::transform(&*result.begin(), &*result.begin() + result.size());
-         if(result.size() && (result[0] == s_delim))
+         if((!result.empty()) && (result[0] == s_delim))
             break;
          std::size_t i;
          for(i = 0; i < result.size(); ++i)
@@ -236,7 +236,7 @@ c_regex_traits<wchar_t>::string_type BOOST_REGEX_CALL c_regex_traits<wchar_t>::l
 #if !defined(BOOST_NO_TEMPLATED_ITERATOR_CONSTRUCTORS)\
                && !BOOST_WORKAROUND(BOOST_MSVC, < 1300)\
                && !BOOST_WORKAROUND(__BORLANDC__, <= 0x0551)
-   if(name.size())
+   if(!name.empty())
       return string_type(name.begin(), name.end());
 #else
    if(name.size())
@@ -311,4 +311,3 @@ int BOOST_REGEX_CALL c_regex_traits<unsigned short>::value(unsigned short c, int
 #endif // BOOST_NO_WREGEX
 
 #endif // __BORLANDC__
-

--- a/src/wide_posix_api.cpp
+++ b/src/wide_posix_api.cpp
@@ -25,9 +25,9 @@
 #include <boost/regex.hpp>
 #include <boost/cregex.hpp>
 
-#include <cwchar>
-#include <cstring>
 #include <cstdio>
+#include <cstring>
+#include <cwchar>
 
 #ifdef BOOST_INTEL
 #pragma warning(disable:981)
@@ -284,8 +284,8 @@ BOOST_REGEX_DECL int BOOST_REGEX_CCALL regexecW(const regex_tW* expression, cons
       std::size_t i;
       for(i = 0; (i < n) && (i < expression->re_nsub + 1); ++i)
       {
-         array[i].rm_so = (m[i].matched == false) ? -1 : (m[i].first - buf);
-         array[i].rm_eo = (m[i].matched == false) ? -1 : (m[i].second - buf);
+         array[i].rm_so = m[i].matched ? (m[i].first - buf) : -1;
+         array[i].rm_eo = m[i].matched ? (m[i].second - buf) : -1;
       }
       // and set anything else to -1:
       for(i = expression->re_nsub + 1; i < n; ++i)
@@ -313,7 +313,3 @@ BOOST_REGEX_DECL void BOOST_REGEX_CCALL regfreeW(regex_tW* expression)
 } // namespace boost;
 
 #endif
-
-
-
-


### PR DESCRIPTION
Use BOOST_OVERRIDE to fix GCC -Wsuggest-override and Clang-tidy modernize-use-override warnings.
Also fixed Clang-tidy modernize-redundant-void-arg, readability-container-size-empty, and some readability-simplify-boolean-expr warnings.
Alphabetical order of STL headers.
Fix some misspellings.