### PR TITLE
Fixes wrong type for mutex in regex v5

### DIFF
--- a/include/boost/regex/v5/mem_block_cache.hpp
+++ b/include/boost/regex/v5/mem_block_cache.hpp
@@ -85,10 +85,10 @@ struct mem_block_node
 struct mem_block_cache
 {
    // this member has to be statically initialsed:
-   mem_block_node* next;
-   unsigned cached_blocks;
+   mem_block_node* next { nullptr };
+   unsigned cached_blocks { 0 };
 #ifdef BOOST_HAS_THREADS
-   boost::static_mutex mut;
+   std::mutex mut;
 #endif
 
    ~mem_block_cache()
@@ -133,11 +133,7 @@ struct mem_block_cache
    }
    static mem_block_cache& instance()
    {
-#ifdef BOOST_HAS_THREADS
-      static mem_block_cache block_cache = { 0, 0, BOOST_STATIC_MUTEX_INIT, };
-#else
-      static mem_block_cache block_cache = { 0, 0, };
-#endif
+      static mem_block_cache block_cache;
       return block_cache;
    }
 };


### PR DESCRIPTION
With the Boost.Regex to header-only library, the declaration of a mutex that should have been changed from `boost::static_mutex` to `std::mutex` was left behind. This was preventing regex from being built for older arm platforms [[1]]

[1]: https://github.com/openwrt/packages/issues/15725

Signed-off-by: Carlos Miguel Ferreira <carlosmf.pt@gmail.com>