### PR TITLE
Fix ICU libs detection when ICU resources are in a separate directory

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -114,6 +114,28 @@ if ! $(disable-icu)
       <runtime-link>static:<define>U_STATIC_IMPLEMENTATION=1
       ;
 
+   if [ modules.peek : ICU_DATA_DIR ]
+   {
+       rule data-dir-options ( properties * )
+       {
+          local result ;
+          local data_dir = [ modules.peek : ICU_DATA_DIR ] ;
+          if <toolset>emscripten in $(properties)
+          {
+             result = <define>ICU_DATA_DIR=\\\"/$(data_dir:BS)\\\"
+                      "<linkflags>--embed-file $(data_dir)@/$(data_dir:BS)"
+                      ;
+          }
+          else
+          {
+             result = <define>ICU_DATA_DIR=\\\"$(data_dir)\\\" ;
+          }
+          return $(result) ;
+       }
+
+       ICU_OPTS += <conditional>@data-dir-options ;
+   }
+
 }
 
 exe has_icu : has_icu_test.cpp : $(ICU_OPTS) ;

--- a/build/has_icu_test.cpp
+++ b/build/has_icu_test.cpp
@@ -28,6 +28,10 @@ void print_error(UErrorCode err, const char* func)
 
 int main()
 {
+#ifdef ICU_DATA_DIR
+   ::u_setDataDirectory(ICU_DATA_DIR);
+#endif
+
    // To detect possible binary mismatches between the installed ICU build, and whatever
    // C++ std lib's we're using, we need to:
    // * Make sure we call ICU C++ API's


### PR DESCRIPTION
ICU supports build setups when its data is loaded at runtime from a separate directory. In this case ICU is not usable until `u_setDataDirectory` is called with a proper directory path.