### PR TITLE
Fix linking with ICU libs when building with clang-cl

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -110,6 +110,7 @@ if ! $(disable-icu)
       <runtime-link>static:<library>icuuc
       <runtime-link>static:<library>icudt
       <runtime-link>static:<library>icuin
+      <target-os>windows,<toolset>clang:<linkflags>"advapi32.lib"
       <define>BOOST_HAS_ICU=1 
       <runtime-link>static:<define>U_STATIC_IMPLEMENTATION=1
       ;


### PR DESCRIPTION
When linking with ICU at least on clang-cl setup (not sure about cl) `advapi32.lib` is needed.