### PR TITLE
regex : fix dead loop in parse_repeat()

### DIFF
--- a/include/boost/regex/v4/basic_regex_parser.hpp
+++ b/include/boost/regex/v4/basic_regex_parser.hpp
@@ -1093,9 +1093,10 @@ bool basic_regex_parser<charT, traits>::parse_repeat(std::size_t low, std::size_
          // Check for illegal following quantifier, we have to do this here, because
          // the extra states we insert below circumvents our usual error checking :-(
          //
-         bool contin = false;
+         bool contin;
          do
          {
+            contin = false;
             if ((this->flags() & (regbase::main_option_type | regbase::mod_x | regbase::no_perl_ex)) == regbase::mod_x)
             {
                // whitespace skip:

--- a/include/boost/regex/v5/basic_regex_parser.hpp
+++ b/include/boost/regex/v5/basic_regex_parser.hpp
@@ -1067,9 +1067,10 @@ bool basic_regex_parser<charT, traits>::parse_repeat(std::size_t low, std::size_
          // Check for illegal following quantifier, we have to do this here, because
          // the extra states we insert below circumvents our usual error checking :-(
          //
-         bool contin = false;
+         bool contin;
          do
          {
+            contin = false;
             if ((this->flags() & (regbase::main_option_type | regbase::mod_x | regbase::no_perl_ex)) == regbase::mod_x)
             {
                // whitespace skip:


### PR DESCRIPTION
There is a bug in parse_repeat(), after deal with comment the
contin value will be always true. So we enter a dead loop. To
deal with this, we assign contin to false each time we enter
the loop.
Testcase: boost::regex(std::string("1?+(?#)1"))

Signed-off-by: Xu Huijie <xuhuijie2@huawei.com>