### PR TITLE
Change \B to be the opposite of \b.

### DIFF
--- a/doc/history.qbk
+++ b/doc/history.qbk
@@ -14,6 +14,16 @@ Currently open issues can be viewed [@https://github.com/boostorg/regex/issues?q
 
 All issues including closed ones can be viewed [@https://github.com/boostorg/regex/issues?q=is%3Aissue+is%3Aclosed here].
 
+[h4 Boost.Regex-7.0.0 (Boost-1.78.0)]
+
+* [*Breaking Change:] Change \B to be the opposite of \b as per Perl behaviour.
+* Change w32_regex_traits.hpp so that windows.h is no longer included.
+
+[h4 Boost.Regex-6.0.0 (Boost-1.77.0)]
+
+* Big change to header only library.
+* Deprecate C++03 support.
+
 [h4 Boost.Regex-5.1.4 (Boost-172.0)]
 
 * Minor build fixes, see [@https://github.com/boostorg/regex/issues/89 #89].

--- a/doc/regex.qbk
+++ b/doc/regex.qbk
@@ -8,7 +8,7 @@
         [@http://www.boost.org/LICENSE_1_0.txt])
     ]
     [authors [Maddock, John]]
-    [version 5.1.4]
+    [version 7.0.0]
     [/last-revision $Date$]
 ]
 

--- a/include/boost/regex/v5/perl_matcher_common.hpp
+++ b/include/boost/regex/v5/perl_matcher_common.hpp
@@ -471,6 +471,11 @@ bool perl_matcher<BidiIterator, Allocator, traits>::match_word_boundary()
 template <class BidiIterator, class Allocator, class traits>
 bool perl_matcher<BidiIterator, Allocator, traits>::match_within_word()
 {
+   bool b = !match_word_boundary();
+   if(b)
+      pstate = pstate->next.p;
+   return b;
+   /*
    if(position == last)
       return false;
    // both prev and this character must be m_word_mask:
@@ -492,6 +497,7 @@ bool perl_matcher<BidiIterator, Allocator, traits>::match_within_word()
       }
    }
    return false;
+   */
 }
 
 template <class BidiIterator, class Allocator, class traits>

--- a/test/regress/test_escapes.cpp
+++ b/test/regress/test_escapes.cpp
@@ -112,6 +112,7 @@ void test_assertion_escapes()
    TEST_REGEX_SEARCH("\\By\\b", perl, "xy", match_default, make_array(1, 2, -2, -2));
    TEST_REGEX_SEARCH("\\by\\B", perl, "yz", match_default, make_array(0, 1, -2, -2));
    TEST_REGEX_SEARCH("\\B\\*\\B", perl, " * ", match_default, make_array(1, 2, -2, -2));
+   TEST_REGEX_SEARCH(".\\B.", perl, "!?", match_default, make_array(0, 2, -2, -2));
    // buffer operators:
    TEST_REGEX_SEARCH("\\`abc", perl, "abc", match_default, make_array(0, 3, -2, -2));
    TEST_REGEX_SEARCH("\\`abc", perl, "\nabc", match_default, make_array(-2, -2));


### PR DESCRIPTION
Also update docs.
Fixes https://github.com/boostorg/regex/issues/123.