### PR TITLE
Disallow repeating a case-change group.

### DIFF
--- a/include/boost/regex/v5/basic_regex_parser.hpp
+++ b/include/boost/regex/v5/basic_regex_parser.hpp
@@ -1034,6 +1034,7 @@ bool basic_regex_parser<charT, traits>::parse_repeat(std::size_t low, std::size_
       case syntax_element_jump:
       case syntax_element_startmark:
       case syntax_element_backstep:
+      case syntax_element_toggle_case:
          // can't legally repeat any of the above:
          fail(regex_constants::error_badrepeat, m_position - m_base);
          return false;
@@ -3107,7 +3108,13 @@ bool basic_regex_parser<charT, traits>::unwind_alts(std::ptrdiff_t last_paren_st
       m_alt_jumps.pop_back();
       this->m_pdata->m_data.align();
       re_jump* jmp = static_cast<re_jump*>(this->getaddress(jump_offset));
-      BOOST_REGEX_ASSERT(jmp->type == syntax_element_jump);
+      if (jmp->type != syntax_element_jump)
+      {
+         // Something really bad happened, this used to be an assert, 
+         // but we'll make it an error just in case we should ever get here.
+         fail(regex_constants::error_unknown, this->m_position - this->m_base, "Internal logic failed while compiling the expression, probably you added a repeat to something non-repeatable!");
+         return false;
+      }
       jmp->alt.i = this->m_pdata->m_data.size() - jump_offset;
    }
    return true;

--- a/test/regress/test_simple_repeats.cpp
+++ b/test/regress/test_simple_repeats.cpp
@@ -496,5 +496,13 @@ void test_pocessive_repeats()
    TEST_INVALID_REGEX("(ab + + +)", perl | mod_x);
    TEST_INVALID_REGEX("(ab + + ?)", perl | mod_x);
 
+#ifndef BOOST_REGEX_CXX03
+   // Some bug cases from https://github.com/boostorg/regex/issues/151
+   TEST_INVALID_REGEX("a|?+", perl | mod_x);
+   TEST_INVALID_REGEX("(?xi)a|?+", perl | mod_x);
+   TEST_INVALID_REGEX("(?xi)a|#\r*", perl | mod_x);
+   TEST_INVALID_REGEX("(?xi)|#\r*", perl | mod_x);
+   TEST_INVALID_REGEX("(?xi)|?+#\r*", perl | mod_x);
+#endif
 }
 


### PR DESCRIPTION
Turn assertion into an error.
Fixes: https://github.com/boostorg/regex/issues/151