### PR TITLE
Fix unused variable warnings

### DIFF
--- a/include/boost/regex/v5/icu.hpp
+++ b/include/boost/regex/v5/icu.hpp
@@ -190,8 +190,8 @@ public:
       constexpr char_class_type mask_xdigit = char_class_type(1) << offset_xdigit;
       constexpr char_class_type mask_underscore = char_class_type(1) << offset_underscore;
       constexpr char_class_type mask_unicode = char_class_type(1) << offset_unicode;
-      constexpr char_class_type mask_any = char_class_type(1) << offset_any;
-      constexpr char_class_type mask_ascii = char_class_type(1) << offset_ascii;
+      //constexpr char_class_type mask_any = char_class_type(1) << offset_any;
+      //constexpr char_class_type mask_ascii = char_class_type(1) << offset_ascii;
       constexpr char_class_type mask_horizontal = char_class_type(1) << offset_horizontal;
       constexpr char_class_type mask_vertical = char_class_type(1) << offset_vertical;
 
@@ -365,15 +365,15 @@ private:
 
    static char_class_type lookup_icu_mask(const ::UChar32* p1, const ::UChar32* p2)
    {
-      constexpr char_class_type mask_blank = char_class_type(1) << offset_blank;
-      constexpr char_class_type mask_space = char_class_type(1) << offset_space;
-      constexpr char_class_type mask_xdigit = char_class_type(1) << offset_xdigit;
-      constexpr char_class_type mask_underscore = char_class_type(1) << offset_underscore;
-      constexpr char_class_type mask_unicode = char_class_type(1) << offset_unicode;
+      //constexpr char_class_type mask_blank = char_class_type(1) << offset_blank;
+      //constexpr char_class_type mask_space = char_class_type(1) << offset_space;
+      //constexpr char_class_type mask_xdigit = char_class_type(1) << offset_xdigit;
+      //constexpr char_class_type mask_underscore = char_class_type(1) << offset_underscore;
+      //constexpr char_class_type mask_unicode = char_class_type(1) << offset_unicode;
       constexpr char_class_type mask_any = char_class_type(1) << offset_any;
       constexpr char_class_type mask_ascii = char_class_type(1) << offset_ascii;
-      constexpr char_class_type mask_horizontal = char_class_type(1) << offset_horizontal;
-      constexpr char_class_type mask_vertical = char_class_type(1) << offset_vertical;
+      //constexpr char_class_type mask_horizontal = char_class_type(1) << offset_horizontal;
+      //constexpr char_class_type mask_vertical = char_class_type(1) << offset_vertical;
 
       static const ::UChar32 prop_name_table[] = {
          /* any */  'a', 'n', 'y',


### PR DESCRIPTION
Will fix the following unused variable warnings:

```
In file included from Boost/1.77.0/include/boost/regex/icu.hpp:27:
Boost/1.77.0/include/boost/regex/v5/icu.hpp:194:33: warning: unused variable 'mask_ascii' [-Wunused-variable]
      constexpr char_class_type mask_ascii = char_class_type(1) << offset_ascii;
                                ^
Boost/1.77.0/include/boost/regex/v5/icu.hpp:193:33: warning: unused variable 'mask_any' [-Wunused-variable]
      constexpr char_class_type mask_any = char_class_type(1) << offset_any;
                                ^
Boost/1.77.0/include/boost/regex/v5/icu.hpp:370:33: warning: unused variable 'mask_xdigit' [-Wunused-variable]
      constexpr char_class_type mask_xdigit = char_class_type(1) << offset_xdigit;
                                ^
Boost/1.77.0/include/boost/regex/v5/icu.hpp:371:33: warning: unused variable 'mask_underscore' [-Wunused-variable]
      constexpr char_class_type mask_underscore = char_class_type(1) << offset_underscore;
                                ^
Boost/1.77.0/include/boost/regex/v5/icu.hpp:376:33: warning: unused variable 'mask_vertical' [-Wunused-variable]
      constexpr char_class_type mask_vertical = char_class_type(1) << offset_vertical;
                                ^
Boost/1.77.0/include/boost/regex/v5/icu.hpp:369:33: warning: unused variable 'mask_space' [-Wunused-variable]
      constexpr char_class_type mask_space = char_class_type(1) << offset_space;
                                ^
Boost/1.77.0/include/boost/regex/v5/icu.hpp:372:33: warning: unused variable 'mask_unicode' [-Wunused-variable]
      constexpr char_class_type mask_unicode = char_class_type(1) << offset_unicode;
                                ^
Boost/1.77.0/include/boost/regex/v5/icu.hpp:375:33: warning: unused variable 'mask_horizontal' [-Wunused-variable]
      constexpr char_class_type mask_horizontal = char_class_type(1) << offset_horizontal;
                                ^
Boost/1.77.0/include/boost/regex/v5/icu.hpp:368:33: warning: unused variable 'mask_blank' [-Wunused-variable]
      constexpr char_class_type mask_blank = char_class_type(1) << offset_blank;
```
