### PR TITLE
fix(comilation): mem_block_cache

### DIFF
--- a/include/boost/regex/v4/mem_block_cache.hpp
+++ b/include/boost/regex/v4/mem_block_cache.hpp
@@ -38,6 +38,8 @@
 namespace boost{
 namespace BOOST_REGEX_DETAIL_NS{
 
+#if BOOST_REGEX_MAX_CACHE_BLOCKS != 0
+
 #ifdef BOOST_REGEX_MEM_BLOCK_CACHE_LOCK_FREE /* lock free implementation */
 struct mem_block_cache
 {
@@ -147,7 +149,17 @@ struct mem_block_cache
 };
 #endif
 
-#if BOOST_REGEX_MAX_CACHE_BLOCKS == 0
+inline void* BOOST_REGEX_CALL get_mem_block()
+{
+   return mem_block_cache::instance().get();
+}
+
+inline void BOOST_REGEX_CALL put_mem_block(void* p)
+{
+   mem_block_cache::instance().put(p);
+}
+
+#else
 
 inline void* BOOST_REGEX_CALL get_mem_block()
 {
@@ -159,19 +171,8 @@ inline void BOOST_REGEX_CALL put_mem_block(void* p)
    ::operator delete(p);
 }
 
-#else
-
-inline void* BOOST_REGEX_CALL get_mem_block()
-{
-   return mem_block_cache::instance().get();
-}
-
-inline void BOOST_REGEX_CALL put_mem_block(void* p)
-{
-   mem_block_cache::instance().put(p);
-}
-
 #endif
+
 }
 } // namespace boost
 

--- a/include/boost/regex/v5/mem_block_cache.hpp
+++ b/include/boost/regex/v5/mem_block_cache.hpp
@@ -34,6 +34,8 @@
 namespace boost{
 namespace BOOST_REGEX_DETAIL_NS{
 
+#if BOOST_REGEX_MAX_CACHE_BLOCKS != 0
+
 #ifdef BOOST_REGEX_MEM_BLOCK_CACHE_LOCK_FREE /* lock free implementation */
 struct mem_block_cache
 {
@@ -139,7 +141,17 @@ struct mem_block_cache
 };
 #endif
 
-#if BOOST_REGEX_MAX_CACHE_BLOCKS == 0
+inline void*  get_mem_block()
+{
+   return mem_block_cache::instance().get();
+}
+
+inline void  put_mem_block(void* p)
+{
+   mem_block_cache::instance().put(p);
+}
+
+#else
 
 inline void*  get_mem_block()
 {
@@ -149,18 +161,6 @@ inline void*  get_mem_block()
 inline void  put_mem_block(void* p)
 {
    ::operator delete(p);
-}
-
-#else
-
-inline void*  get_mem_block()
-{
-   return mem_block_cache::instance().get();
-}
-
-inline void  put_mem_block(void* p)
-{
-   mem_block_cache::instance().put(p);
 }
 
 #endif


### PR DESCRIPTION
issue:
- BOOST_REGEX_MAX_CACHE_BLOCKS=0 can't compile if std::atomic is available
- BOOST_REGEX_MAX_CACHE_BLOCKS=0 does only work together with BOOST_NO_CXX11_HDR_ATOMIC

fix:
- hide mem_block_cache if BOOST_REGEX_MAX_CACHE_BLOCKS=0

error:

```shell
mem_block_cache.hpp:75:60: error: too many initializers for 'std::atomic<void*> [0] 
75 |       static mem_block_cache block_cache = { { {nullptr} } };
```