### PR TITLE
Port to `boost/core/snprintf.hpp`

### DIFF
--- a/include/boost/regex/v4/regex_workaround.hpp
+++ b/include/boost/regex/v4/regex_workaround.hpp
@@ -25,7 +25,6 @@
 #include <cstdlib>
 #include <cstddef>
 #include <cassert>
-#include <cstdio>
 #include <climits>
 #include <string>
 #include <stdexcept>
@@ -50,7 +49,7 @@
 
 #if defined(BOOST_NO_STDC_NAMESPACE)
 namespace std{
-   using ::sprintf; using ::strcpy; using ::strcat; using ::strlen;
+   using ::strcpy; using ::strcat; using ::strlen;
 }
 #endif
 
@@ -198,10 +197,10 @@ namespace boost{ namespace BOOST_REGEX_DETAIL_NS{
       const char *strSource 
    )
    {
-	  std::size_t lenSourceWithNull = std::strlen(strSource) + 1;
-	  if (lenSourceWithNull > sizeInBytes)
+      std::size_t lenSourceWithNull = std::strlen(strSource) + 1;
+      if (lenSourceWithNull > sizeInBytes)
          return 1;
-	  std::memcpy(strDestination, strSource, lenSourceWithNull);
+      std::memcpy(strDestination, strSource, lenSourceWithNull);
       return 0;
    }
    inline std::size_t strcat_s(
@@ -210,11 +209,11 @@ namespace boost{ namespace BOOST_REGEX_DETAIL_NS{
       const char *strSource 
    )
    {
-	  std::size_t lenSourceWithNull = std::strlen(strSource) + 1;
-	  std::size_t lenDestination = std::strlen(strDestination);
-	  if (lenSourceWithNull + lenDestination > sizeInBytes)
+      std::size_t lenSourceWithNull = std::strlen(strSource) + 1;
+      std::size_t lenDestination = std::strlen(strDestination);
+      if (lenSourceWithNull + lenDestination > sizeInBytes)
          return 1;
-	  std::memcpy(strDestination + lenDestination, strSource, lenSourceWithNull);
+      std::memcpy(strDestination + lenDestination, strSource, lenSourceWithNull);
       return 0;
    }
 

--- a/src/posix_api.cpp
+++ b/src/posix_api.cpp
@@ -22,11 +22,12 @@
 #include <boost/regex.hpp>
 #include <boost/cregex.hpp>
 #include <boost/cstdint.hpp>
-#include <cstdio>
+#include <boost/core/snprintf.hpp>
+#include <cstddef>
+#include <cstring>
 
 #if defined(BOOST_NO_STDC_NAMESPACE)
 namespace std{
-   using ::sprintf;
    using ::strcpy;
    using ::strcmp;
 }
@@ -177,29 +178,17 @@ BOOST_REGEX_DECL regsize_t BOOST_REGEX_CCALL regerrorA(int code, const regex_tA*
             // We're converting an integer i to a string, and since i <= REG_E_UNKNOWN
             // a five character string is *always* large enough:
             //
-#if BOOST_CXX_VERSION >= 201103
-            int r = (std::snprintf)(localbuf, 5, "%d", i);
-#elif BOOST_WORKAROUND(BOOST_MSVC, >= 1400) && !defined(_WIN32_WCE) && !defined(UNDER_CE)
-            int r = (::sprintf_s)(localbuf, 5, "%d", i);
-#else
-            int r = (std::sprintf)(localbuf, "%d", i);
-#endif
+            int r = boost::core::snprintf(localbuf, 5, "%d", i);
             if(r < 0)
-               return 0; // sprintf failed
+               return 0; // snprintf failed
             if(std::strlen(localbuf) < buf_size)
                BOOST_REGEX_DETAIL_NS::strcpy_s(buf, buf_size, localbuf);
             return std::strlen(localbuf) + 1;
          }
       }
-#if BOOST_CXX_VERSION >= 201103
-      int r = (::snprintf)(localbuf, 5, "%d", 0);
-#elif BOOST_WORKAROUND(BOOST_MSVC, >= 1400) && !defined(_WIN32_WCE) && !defined(UNDER_CE)
-      int r = (::sprintf_s)(localbuf, 5, "%d", 0);
-#else
-      int r = (std::sprintf)(localbuf, "%d", 0);
-#endif
+      int r = boost::core::snprintf(localbuf, 5, "%d", 0);
       if(r < 0)
-         return 0; // sprintf failed
+         return 0; // snprintf failed
       if(std::strlen(localbuf) < buf_size)
          BOOST_REGEX_DETAIL_NS::strcpy_s(buf, buf_size, localbuf);
       return std::strlen(localbuf) + 1;
@@ -236,7 +225,7 @@ BOOST_REGEX_DECL int BOOST_REGEX_CCALL regexecA(const regex_tA* expression, cons
    const char* end;
    const char* start;
    cmatch m;
-   
+
    if(eflags & REG_NOTBOL)
       flags |= match_not_bol;
    if(eflags & REG_NOTEOL)

--- a/src/wide_posix_api.cpp
+++ b/src/wide_posix_api.cpp
@@ -25,21 +25,14 @@
 #include <boost/regex.hpp>
 #include <boost/cregex.hpp>
 #include <boost/cstdint.hpp>
+#include <boost/core/snprintf.hpp>
 
-#include <cstdio>
+#include <cstddef>
 #include <cstring>
 #include <cwchar>
 
 #ifdef BOOST_INTEL
 #pragma warning(disable:981)
-#endif
-
-#if defined(BOOST_NO_STDC_NAMESPACE) || defined(__NetBSD__)
-namespace std{
-#  ifndef BOOST_NO_SWPRINTF
-      using ::swprintf;
-#  endif
-}
 #endif
 
 
@@ -178,7 +171,6 @@ BOOST_REGEX_DECL regsize_t BOOST_REGEX_CCALL regerrorW(int code, const regex_tW*
       }
       return result;
    }
-#if !defined(BOOST_NO_SWPRINTF)
    if(code == REG_ATOI)
    {
       wchar_t localbuf[5];
@@ -188,11 +180,7 @@ BOOST_REGEX_DECL regsize_t BOOST_REGEX_CCALL regerrorW(int code, const regex_tW*
       {
          if(std::wcscmp(e->re_endp, wnames[i]) == 0)
          {
-#if defined(_WIN32_WCE) && !defined(UNDER_CE)
-            (std::swprintf)(localbuf, L"%d", i);
-#else
-            (std::swprintf)(localbuf, 5, L"%d", i);
-#endif
+            boost::core::swprintf(localbuf, 5, L"%d", i);
             if(std::wcslen(localbuf) < buf_size)
 #if BOOST_WORKAROUND(BOOST_MSVC, >= 1400) && !defined(_WIN32_WCE) && !defined(UNDER_CE)
                ::wcscpy_s(buf, buf_size, localbuf);
@@ -202,11 +190,7 @@ BOOST_REGEX_DECL regsize_t BOOST_REGEX_CCALL regerrorW(int code, const regex_tW*
             return std::wcslen(localbuf) + 1;
          }
       }
-#if defined(_WIN32_WCE) && !defined(UNDER_CE)
-      (std::swprintf)(localbuf, L"%d", 0);
-#else
-      (std::swprintf)(localbuf, 5, L"%d", 0);
-#endif
+      boost::core::swprintf(localbuf, 5, L"%d", 0);
       if(std::wcslen(localbuf) < buf_size)
 #if BOOST_WORKAROUND(BOOST_MSVC, >= 1400) && !defined(_WIN32_WCE) && !defined(UNDER_CE)
          ::wcscpy_s(buf, buf_size, localbuf);
@@ -215,7 +199,6 @@ BOOST_REGEX_DECL regsize_t BOOST_REGEX_CCALL regerrorW(int code, const regex_tW*
 #endif
       return std::wcslen(localbuf) + 1;
    }
-#endif
    if(code <= (int)REG_E_UNKNOWN)
    {
       std::string p;
@@ -248,7 +231,7 @@ BOOST_REGEX_DECL int BOOST_REGEX_CCALL regexecW(const regex_tW* expression, cons
    const wchar_t* end;
    const wchar_t* start;
    wcmatch m;
-   
+
    if(eflags & REG_NOTBOL)
       flags |= match_not_bol;
    if(eflags & REG_NOTEOL)


### PR DESCRIPTION
This replaces `snprintf`/`swprintf` workarounds with the more portable definitions in Boost.Core. This fixes compilation errors on MinGW32 introduced in a142dfecda7644e58382f4b6c527f37309af03f4.

Also converted a few tabs to spaces.
