### PR TITLE
Simplify snprintf workaround usage.

### DIFF
--- a/include/boost/regex/v4/regex_workaround.hpp
+++ b/include/boost/regex/v4/regex_workaround.hpp
@@ -198,10 +198,10 @@ namespace boost{ namespace BOOST_REGEX_DETAIL_NS{
       const char *strSource 
    )
    {
-	  std::size_t lenSourceWithNull = std::strlen(strSource) + 1;
-	  if (lenSourceWithNull > sizeInBytes)
+     std::size_t lenSourceWithNull = std::strlen(strSource) + 1;
+     if (lenSourceWithNull > sizeInBytes)
          return 1;
-	  std::memcpy(strDestination, strSource, lenSourceWithNull);
+     std::memcpy(strDestination, strSource, lenSourceWithNull);
       return 0;
    }
    inline std::size_t strcat_s(
@@ -210,11 +210,11 @@ namespace boost{ namespace BOOST_REGEX_DETAIL_NS{
       const char *strSource 
    )
    {
-	  std::size_t lenSourceWithNull = std::strlen(strSource) + 1;
-	  std::size_t lenDestination = std::strlen(strDestination);
-	  if (lenSourceWithNull + lenDestination > sizeInBytes)
+     std::size_t lenSourceWithNull = std::strlen(strSource) + 1;
+     std::size_t lenDestination = std::strlen(strDestination);
+     if (lenSourceWithNull + lenDestination > sizeInBytes)
          return 1;
-	  std::memcpy(strDestination + lenDestination, strSource, lenSourceWithNull);
+     std::memcpy(strDestination + lenDestination, strSource, lenSourceWithNull);
       return 0;
    }
 

--- a/include/boost/regex/v5/regex_workaround.hpp
+++ b/include/boost/regex/v5/regex_workaround.hpp
@@ -116,10 +116,10 @@ namespace boost{ namespace BOOST_REGEX_DETAIL_NS{
       const char *strSource 
    )
    {
-	  std::size_t lenSourceWithNull = std::strlen(strSource) + 1;
-	  if (lenSourceWithNull > sizeInBytes)
+     std::size_t lenSourceWithNull = std::strlen(strSource) + 1;
+     if (lenSourceWithNull > sizeInBytes)
          return 1;
-	  std::memcpy(strDestination, strSource, lenSourceWithNull);
+     std::memcpy(strDestination, strSource, lenSourceWithNull);
       return 0;
    }
    inline std::size_t strcat_s(
@@ -128,11 +128,11 @@ namespace boost{ namespace BOOST_REGEX_DETAIL_NS{
       const char *strSource 
    )
    {
-	  std::size_t lenSourceWithNull = std::strlen(strSource) + 1;
-	  std::size_t lenDestination = std::strlen(strDestination);
-	  if (lenSourceWithNull + lenDestination > sizeInBytes)
+     std::size_t lenSourceWithNull = std::strlen(strSource) + 1;
+     std::size_t lenDestination = std::strlen(strDestination);
+     if (lenSourceWithNull + lenDestination > sizeInBytes)
          return 1;
-	  std::memcpy(strDestination + lenDestination, strSource, lenSourceWithNull);
+     std::memcpy(strDestination + lenDestination, strSource, lenSourceWithNull);
       return 0;
    }
 

--- a/src/posix_api.cpp
+++ b/src/posix_api.cpp
@@ -22,19 +22,15 @@
 #include <boost/cregex.hpp>
 #include <cstdio>
 
-#if defined(BOOST_NO_STDC_NAMESPACE)
-namespace std{
-   using ::sprintf;
-   using ::strcpy;
-   using ::strcmp;
-}
-#endif
-
 #ifndef BOOST_WORKAROUND
 #define BOOST_WORKAROUND(x, y) false
 #endif
 
-
+#ifndef BOOST_REGEX_STANDALONE
+#include <boost/core/snprintf.hpp>
+#else
+namespace boost { namespace core { using std::snprintf; } }
+#endif
 
 namespace boost{
 
@@ -180,13 +176,7 @@ BOOST_REGEX_DECL regsize_t BOOST_REGEX_CCALL regerrorA(int code, const regex_tA*
             // We're converting an integer i to a string, and since i <= REG_E_UNKNOWN
             // a five character string is *always* large enough:
             //
-#if !defined(BOOST_CXX_VERSION) || (BOOST_CXX_VERSION >= 201103)
-            int r = (std::snprintf)(localbuf, 5, "%d", i);
-#elif BOOST_WORKAROUND(BOOST_MSVC, >= 1400) && !defined(_WIN32_WCE) && !defined(UNDER_CE)
-            int r = (::sprintf_s)(localbuf, 5, "%d", i);
-#else
-            int r = (std::sprintf)(localbuf, "%d", i);
-#endif
+            int r = (boost::core::snprintf)(localbuf, 5, "%d", i);
             if(r < 0)
                return 0; // sprintf failed
             if(std::strlen(localbuf) < buf_size)
@@ -194,13 +184,7 @@ BOOST_REGEX_DECL regsize_t BOOST_REGEX_CCALL regerrorA(int code, const regex_tA*
             return std::strlen(localbuf) + 1;
          }
       }
-#if  !defined(BOOST_CXX_VERSION) || (BOOST_CXX_VERSION >= 201103)
-      int r = (::snprintf)(localbuf, 5, "%d", 0);
-#elif BOOST_WORKAROUND(BOOST_MSVC, >= 1400) && !defined(_WIN32_WCE) && !defined(UNDER_CE)
-      int r = (::sprintf_s)(localbuf, 5, "%d", 0);
-#else
-      int r = (std::sprintf)(localbuf, "%d", 0);
-#endif
+      int r = (boost::core::snprintf)(localbuf, 5, "%d", 0);
       if(r < 0)
          return 0; // sprintf failed
       if(std::strlen(localbuf) < buf_size)

--- a/src/wide_posix_api.cpp
+++ b/src/wide_posix_api.cpp
@@ -25,6 +25,12 @@
 #include <boost/regex.hpp>
 #include <boost/cregex.hpp>
 
+#ifndef BOOST_REGEX_STANDALONE
+#include <boost/core/snprintf.hpp>
+#else
+namespace boost { namespace core { using std::swprintf; } }
+#endif
+
 #ifndef BOOST_WORKAROUND
 #define BOOST_WORKAROUND(x, y) false
 #endif
@@ -185,7 +191,7 @@ BOOST_REGEX_DECL regsize_t BOOST_REGEX_CCALL regerrorW(int code, const regex_tW*
 #if defined(_WIN32_WCE) && !defined(UNDER_CE)
             (std::swprintf)(localbuf, L"%d", i);
 #else
-            (std::swprintf)(localbuf, 5, L"%d", i);
+            (boost::core::swprintf)(localbuf, 5, L"%d", i);
 #endif
             if(std::wcslen(localbuf) < buf_size)
 #if BOOST_WORKAROUND(BOOST_MSVC, >= 1400) && !defined(_WIN32_WCE) && !defined(UNDER_CE)
@@ -199,7 +205,7 @@ BOOST_REGEX_DECL regsize_t BOOST_REGEX_CCALL regerrorW(int code, const regex_tW*
 #if defined(_WIN32_WCE) && !defined(UNDER_CE)
       (std::swprintf)(localbuf, L"%d", 0);
 #else
-      (std::swprintf)(localbuf, 5, L"%d", 0);
+      (boost::core::swprintf)(localbuf, 5, L"%d", 0);
 #endif
       if(std::wcslen(localbuf) < buf_size)
 #if BOOST_WORKAROUND(BOOST_MSVC, >= 1400) && !defined(_WIN32_WCE) && !defined(UNDER_CE)

--- a/src/wide_posix_api.cpp
+++ b/src/wide_posix_api.cpp
@@ -178,7 +178,6 @@ BOOST_REGEX_DECL regsize_t BOOST_REGEX_CCALL regerrorW(int code, const regex_tW*
       }
       return result;
    }
-#if !defined(BOOST_NO_SWPRINTF)
    if(code == REG_ATOI)
    {
       wchar_t localbuf[5];
@@ -215,7 +214,6 @@ BOOST_REGEX_DECL regsize_t BOOST_REGEX_CCALL regerrorW(int code, const regex_tW*
 #endif
       return std::wcslen(localbuf) + 1;
    }
-#endif
    if(code <= (int)REG_E_UNKNOWN)
    {
       std::string p;

--- a/src/wide_posix_api.cpp
+++ b/src/wide_posix_api.cpp
@@ -37,15 +37,6 @@
 #pragma warning(disable:981)
 #endif
 
-#if defined(BOOST_NO_STDC_NAMESPACE) || defined(__NetBSD__)
-namespace std{
-#  ifndef BOOST_NO_SWPRINTF
-      using ::swprintf;
-#  endif
-}
-#endif
-
-
 namespace boost{
 
 namespace {


### PR DESCRIPTION
Via boost/core/snprintf.hpp
Remove some obsolete workarounds.
Remove tabs in files.
Supersedes https://github.com/boostorg/regex/pull/188.