### PR TITLE
Default empty destructor.

### DIFF
--- a/include/boost/regex/v5/pattern_except.hpp
+++ b/include/boost/regex/v5/pattern_except.hpp
@@ -52,7 +52,7 @@ public:
       , m_position(0)
    {
    }
-   ~regex_error() noexcept override {}
+   ~regex_error() noexcept override = default;
    regex_constants::error_type code()const
    { return m_error_code; }
    std::ptrdiff_t position()const


### PR DESCRIPTION
The compiler-generated copy constructor and copy assignment operator are deprecated since C++11 on classes with user-declared destructors.

This change allows clean compilation with the -Wdeprecated-copy-dtor/-Wdeprecated-copy-with-user-provided-dtor flag.