### PR TITLE
Use "noexcept" instead of "throw()".

### DIFF
--- a/include/boost/regex/v5/basic_regex.hpp
+++ b/include/boost/regex/v5/basic_regex.hpp
@@ -488,7 +488,7 @@ public:
    }
    //
    // swap:
-   void  swap(basic_regex& that)throw()
+   void  swap(basic_regex& that) noexcept
    {
       m_pimpl.swap(that.m_pimpl);
    }


### PR DESCRIPTION
This fixes a -Wdeprecated-dynamic-exception-spec warning with clang.