### PR TITLE
Fix deprecated-declarations error on clang-win

### DIFF
--- a/src/wide_posix_api.cpp
+++ b/src/wide_posix_api.cpp
@@ -169,7 +169,7 @@ BOOST_REGEX_DECL regsize_t BOOST_REGEX_CCALL regerrorW(int code, const regex_tW*
       {
          result = std::wcslen(wnames[code]) + 1;
          if(buf_size >= result)
-#if BOOST_WORKAROUND(BOOST_MSVC, >= 1400) && !defined(_WIN32_WCE) && !defined(UNDER_CE)
+#if (BOOST_WORKAROUND(BOOST_MSVC, >= 1400) && !defined(_WIN32_WCE) && !defined(UNDER_CE)) || (defined(BOOST_CLANG) && defined(_MSC_VER))
             ::wcscpy_s(buf, buf_size, wnames[code]);
 #else
             std::wcscpy(buf, wnames[code]);


### PR DESCRIPTION
This error was seen on the CI of a Boost.Unordered PR, boostorg/unordered#274. Note the failing job [here](https://github.com/boostorg/unordered/actions/runs/10517392958/job/29141588762).

This fix is inspired by [this commit](https://github.com/boostorg/interprocess/commit/2449ba1c743e05f45c991ac27de7bf4621aa2118).