### PR TITLE
Add VERBATIM to the remaining add_custom_target as well

### DIFF
--- a/test/cmake_subdir_test_icu/CMakeLists.txt
+++ b/test/cmake_subdir_test_icu/CMakeLists.txt
@@ -19,4 +19,4 @@ target_link_libraries(quick_icu Boost::regex_icu)
 enable_testing()
 add_test(quick_icu quick_icu)
 
-add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -C $<CONFIG>)
+add_custom_target(check VERBATIM COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -C $<CONFIG>)


### PR DESCRIPTION
Two of these have already been fixed by https://github.com/boostorg/regex/commit/1144c1dad8d036b65b6589fbd653b3d55b08687d, but the third one got missed. This should fix the ubuntu-cmake-check failure.