### PR TITLE
Move <warnings>all from requirements to default-build. Fixes #223.

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -11,9 +11,8 @@ constant boost_dependencies_private :
     /boost/core//boost_core
     ;
 
-project : requirements
-   # default to all warnings on:
-   <warnings>all
+project
+   : default-build <warnings>all
    : common-requirements <library>$(boost_dependencies)
    : requirements <library>$(boost_dependencies_private)
    ;


### PR DESCRIPTION
I've verified that this fixes the Unordered test failure even without the warning fixes applied.