### PR TITLE
#include cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - master
       - develop
+      - feature/**
   pull_request:
   release:
     types: [published, created, edited]

--- a/include/boost/regex/v5/basic_regex.hpp
+++ b/include/boost/regex/v5/basic_regex.hpp
@@ -19,6 +19,15 @@
 #ifndef BOOST_REGEX_V5_BASIC_REGEX_HPP
 #define BOOST_REGEX_V5_BASIC_REGEX_HPP
 
+#include <boost/regex/v5/regbase.hpp>
+#include <boost/regex/v5/syntax_type.hpp>
+#include <boost/regex/v5/regex_traits.hpp>
+#include <boost/regex/v5/states.hpp>
+#include <boost/regex/v5/regex_raw_buffer.hpp>
+
+#include <algorithm>
+#include <limits>
+#include <memory>
 #include <vector>
 
 namespace boost{

--- a/include/boost/regex/v5/basic_regex_creator.hpp
+++ b/include/boost/regex/v5/basic_regex_creator.hpp
@@ -28,6 +28,9 @@
 #endif
 #endif
 
+#include <boost/regex/v5/basic_regex.hpp>
+
+#include <vector>
 #include <set>
 
 namespace boost{

--- a/include/boost/regex/v5/basic_regex_parser.hpp
+++ b/include/boost/regex/v5/basic_regex_parser.hpp
@@ -19,6 +19,13 @@
 #ifndef BOOST_REGEX_V5_BASIC_REGEX_PARSER_HPP
 #define BOOST_REGEX_V5_BASIC_REGEX_PARSER_HPP
 
+#include <boost/regex/v5/basic_regex_creator.hpp>
+
+#include <climits>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
 namespace boost{
 namespace BOOST_REGEX_DETAIL_NS{
 

--- a/include/boost/regex/v5/c_regex_traits.hpp
+++ b/include/boost/regex/v5/c_regex_traits.hpp
@@ -21,7 +21,12 @@
 
 #include <boost/regex/config.hpp>
 #include <boost/regex/v5/regex_workaround.hpp>
+#include <boost/regex/v5/primary_transform.hpp>
+#include <boost/regex/v5/regex_traits_defaults.hpp>
+
 #include <cctype>
+#include <cstdint>
+#include <cwctype>
 
 namespace boost{
 

--- a/include/boost/regex/v5/char_regex_traits.hpp
+++ b/include/boost/regex/v5/char_regex_traits.hpp
@@ -20,6 +20,8 @@
 #ifndef BOOST_REGEX_V5_CHAR_REGEX_TRAITS_HPP
 #define BOOST_REGEX_V5_CHAR_REGEX_TRAITS_HPP
 
+#include <boost/regex/v5/regex_traits.hpp>
+
 namespace boost{
 
 namespace deprecated{

--- a/include/boost/regex/v5/iterator_traits.hpp
+++ b/include/boost/regex/v5/iterator_traits.hpp
@@ -19,6 +19,8 @@
 #ifndef BOOST_REGEX_V5_ITERATOR_TRAITS_HPP
 #define BOOST_REGEX_V5_ITERATOR_TRAITS_HPP
 
+#include <iterator>
+
 namespace boost{
 namespace BOOST_REGEX_DETAIL_NS{
 

--- a/include/boost/regex/v5/match_results.hpp
+++ b/include/boost/regex/v5/match_results.hpp
@@ -19,6 +19,14 @@
 #ifndef BOOST_REGEX_V5_MATCH_RESULTS_HPP
 #define BOOST_REGEX_V5_MATCH_RESULTS_HPP
 
+#include <boost/regex/v5/match_flags.hpp>
+#include <boost/regex/v5/sub_match.hpp>
+#include <boost/regex/v5/basic_regex.hpp>
+#include <boost/regex/v5/regex_format.hpp>
+
+#include <string>
+#include <vector>
+
 namespace boost{
 #ifdef BOOST_REGEX_MSVC
 #pragma warning(push)

--- a/include/boost/regex/v5/mem_block_cache.hpp
+++ b/include/boost/regex/v5/mem_block_cache.hpp
@@ -18,6 +18,8 @@
 #ifndef BOOST_REGEX_V5_MEM_BLOCK_CACHE_HPP
 #define BOOST_REGEX_V5_MEM_BLOCK_CACHE_HPP
 
+#include <boost/regex/config.hpp>
+
 #include <new>
 #ifdef BOOST_HAS_THREADS
 #include <mutex>
@@ -30,6 +32,7 @@
     #define BOOST_REGEX_ATOMIC_POINTER std::atomic
   #endif
 #endif
+
 
 namespace boost{
 namespace BOOST_REGEX_DETAIL_NS{

--- a/include/boost/regex/v5/perl_matcher.hpp
+++ b/include/boost/regex/v5/perl_matcher.hpp
@@ -12,7 +12,18 @@
 #ifndef BOOST_REGEX_MATCHER_HPP
 #define BOOST_REGEX_MATCHER_HPP
 
+#include <boost/regex/v5/match_flags.hpp>
+#include <boost/regex/v5/match_results.hpp>
+#include <boost/regex/v5/regbase.hpp>
 #include <boost/regex/v5/iterator_category.hpp>
+#include <boost/regex/v5/states.hpp>
+#include <boost/regex/v5/regex_traits.hpp>
+
+#ifndef BOOST_REGEX_STANDALONE
+#include <boost/throw_exception.hpp>
+#endif
+
+#include <climits>
 
 #ifdef BOOST_REGEX_MSVC
 #  pragma warning(push)

--- a/include/boost/regex/v5/perl_matcher_common.hpp
+++ b/include/boost/regex/v5/perl_matcher_common.hpp
@@ -20,6 +20,22 @@
 #ifndef BOOST_REGEX_V5_PERL_MATCHER_COMMON_HPP
 #define BOOST_REGEX_V5_PERL_MATCHER_COMMON_HPP
 
+#include <boost/regex/config.hpp>
+
+#ifndef BOOST_REGEX_STANDALONE
+
+#include <boost/config.hpp>
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#pragma once
+#include <boost/regex/v5/perl_matcher.hpp>
+#endif
+
+#endif
+
+#include <boost/regex/v5/basic_regex.hpp>
+#include <boost/regex/v5/match_flags.hpp>
+#include <boost/regex/v5/match_results.hpp>
+
 #ifdef BOOST_REGEX_MSVC
 #  pragma warning(push)
 #pragma warning(disable:4459)

--- a/include/boost/regex/v5/perl_matcher_non_recursive.hpp
+++ b/include/boost/regex/v5/perl_matcher_non_recursive.hpp
@@ -20,6 +20,18 @@
 #ifndef BOOST_REGEX_V5_PERL_MATCHER_NON_RECURSIVE_HPP
 #define BOOST_REGEX_V5_PERL_MATCHER_NON_RECURSIVE_HPP
 
+#include <boost/regex/config.hpp>
+
+#ifndef BOOST_REGEX_STANDALONE
+
+#include <boost/config.hpp>
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#pragma once
+#include <boost/regex/v5/perl_matcher.hpp>
+#endif
+
+#endif
+
 #include <boost/regex/v5/mem_block_cache.hpp>
 
 #ifdef BOOST_REGEX_MSVC

--- a/include/boost/regex/v5/regex_format.hpp
+++ b/include/boost/regex/v5/regex_format.hpp
@@ -21,6 +21,10 @@
 #ifndef BOOST_REGEX_FORMAT_HPP
 #define BOOST_REGEX_FORMAT_HPP
 
+#include <boost/regex/v5/match_flags.hpp>
+#include <boost/regex/v5/sub_match.hpp>
+#include <boost/regex/v5/regex_traits_defaults.hpp>
+
 #include <type_traits>
 #include <functional>
 

--- a/include/boost/regex/v5/regex_grep.hpp
+++ b/include/boost/regex/v5/regex_grep.hpp
@@ -19,6 +19,10 @@
 #ifndef BOOST_REGEX_V5_REGEX_GREP_HPP
 #define BOOST_REGEX_V5_REGEX_GREP_HPP
 
+#include <boost/regex/v5/basic_regex.hpp>
+#include <boost/regex/v5/match_flags.hpp>
+#include <boost/regex/v5/match_results.hpp>
+#include <boost/regex/v5/perl_matcher.hpp>
 
 namespace boost{
 

--- a/include/boost/regex/v5/regex_iterator.hpp
+++ b/include/boost/regex/v5/regex_iterator.hpp
@@ -19,6 +19,9 @@
 #ifndef BOOST_REGEX_V5_REGEX_ITERATOR_HPP
 #define BOOST_REGEX_V5_REGEX_ITERATOR_HPP
 
+#include <boost/regex/v5/basic_regex.hpp>
+#include <boost/regex/v5/match_results.hpp>
+
 #include <memory>
 
 namespace boost{

--- a/include/boost/regex/v5/regex_match.hpp
+++ b/include/boost/regex/v5/regex_match.hpp
@@ -22,6 +22,9 @@
 #ifndef BOOST_REGEX_MATCH_HPP
 #define BOOST_REGEX_MATCH_HPP
 
+#include <boost/regex/v5/match_results.hpp>
+#include <boost/regex/v5/perl_matcher.hpp>
+
 namespace boost{
 
 //

--- a/include/boost/regex/v5/regex_raw_buffer.hpp
+++ b/include/boost/regex/v5/regex_raw_buffer.hpp
@@ -27,6 +27,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <cstring>
 
 namespace boost{
    namespace BOOST_REGEX_DETAIL_NS{

--- a/include/boost/regex/v5/regex_replace.hpp
+++ b/include/boost/regex/v5/regex_replace.hpp
@@ -22,6 +22,10 @@
 #define BOOST_REGEX_V5_REGEX_REPLACE_HPP
 
 
+#include <boost/regex/v5/basic_regex.hpp>
+#include <boost/regex/v5/match_flags.hpp>
+#include <boost/regex/v5/regex_iterator.hpp>
+
 namespace boost{
 
 template <class OutputIterator, class BidirectionalIterator, class traits, class charT, class Formatter>

--- a/include/boost/regex/v5/regex_search.hpp
+++ b/include/boost/regex/v5/regex_search.hpp
@@ -20,6 +20,9 @@
 #define BOOST_REGEX_V5_REGEX_SEARCH_HPP
 
 
+#include <boost/regex/v5/match_results.hpp>
+#include <boost/regex/v5/perl_matcher.hpp>
+
 namespace boost{
 
 template <class BidiIterator, class Allocator, class charT, class traits>

--- a/include/boost/regex/v5/regex_split.hpp
+++ b/include/boost/regex/v5/regex_split.hpp
@@ -21,6 +21,9 @@
 #ifndef BOOST_REGEX_SPLIT_HPP
 #define BOOST_REGEX_SPLIT_HPP
 
+#include <boost/regex/v5/basic_regex.hpp>
+#include <boost/regex/v5/match_results.hpp>
+
 namespace boost{
 
 #ifdef BOOST_REGEX_MSVC

--- a/include/boost/regex/v5/regex_token_iterator.hpp
+++ b/include/boost/regex/v5/regex_token_iterator.hpp
@@ -19,6 +19,10 @@
 #ifndef BOOST_REGEX_V5_REGEX_TOKEN_ITERATOR_HPP
 #define BOOST_REGEX_V5_REGEX_TOKEN_ITERATOR_HPP
 
+#include <boost/regex/v5/basic_regex.hpp>
+#include <boost/regex/v5/match_results.hpp>
+#include <boost/regex/v5/sub_match.hpp>
+
 #include <memory>
 
 namespace boost{

--- a/include/boost/regex/v5/states.hpp
+++ b/include/boost/regex/v5/states.hpp
@@ -19,6 +19,11 @@
 #ifndef BOOST_REGEX_V5_STATES_HPP
 #define BOOST_REGEX_V5_STATES_HPP
 
+#include <boost/regex/v5/regex_raw_buffer.hpp>
+
+#include <climits>
+#include <cstddef>
+
 namespace boost{
 namespace BOOST_REGEX_DETAIL_NS{
 

--- a/include/boost/regex/v5/sub_match.hpp
+++ b/include/boost/regex/v5/sub_match.hpp
@@ -19,6 +19,9 @@
 #ifndef BOOST_REGEX_V5_SUB_MATCH_HPP
 #define BOOST_REGEX_V5_SUB_MATCH_HPP
 
+#include <iterator>
+#include <utility>
+
 namespace boost{
 
 template <class BidiIterator>

--- a/include/boost/regex/v5/u32regex_iterator.hpp
+++ b/include/boost/regex/v5/u32regex_iterator.hpp
@@ -19,6 +19,21 @@
 #ifndef BOOST_REGEX_V5_U32REGEX_ITERATOR_HPP
 #define BOOST_REGEX_V5_U32REGEX_ITERATOR_HPP
 
+#include <boost/regex/config.hpp>
+
+#ifndef BOOST_REGEX_STANDALONE
+
+#include <boost/config.hpp>
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#pragma once
+#include <boost/regex/v5/icu.hpp>
+#endif
+
+#endif
+
+#include <boost/regex/v5/match_flags.hpp>
+#include <boost/regex/v5/match_results.hpp>
+
 namespace boost{
 
 template <class BidirectionalIterator>

--- a/include/boost/regex/v5/u32regex_token_iterator.hpp
+++ b/include/boost/regex/v5/u32regex_token_iterator.hpp
@@ -19,6 +19,18 @@
 #ifndef BOOST_REGEX_V5_U32REGEX_TOKEN_ITERATOR_HPP
 #define BOOST_REGEX_V5_U32REGEX_TOKEN_ITERATOR_HPP
 
+#include <boost/regex/config.hpp>
+
+#ifndef BOOST_REGEX_STANDALONE
+
+#include <boost/config.hpp>
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#pragma once
+#include <boost/regex/v5/icu.hpp>
+#endif
+
+#endif
+
 namespace boost{
 
 #ifdef BOOST_REGEX_MSVC


### PR DESCRIPTION
Update library header files to be fully self-contained so tools like clangd can work with the b2-generated compile commands database.

Also update CI to run for `feature/**` branches.

To handle circular #includes to make tooling happy, we defer to `#pragma once` when appropriate. The code here is a little over-engineered and can theoretically just be `#pragma once` but I wasn't sure how Regex was used in the wild.