### PR TITLE
CI Sanitizers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ on:
   pull_request:
   release:
     types: [published, created, edited]
+
+env:
+  UBSAN_OPTIONS: print_stacktrace=1
+
 jobs:
   ubuntu-jammy:
     runs-on: ubuntu-22.04
@@ -60,7 +64,7 @@ jobs:
         run: ../../../b2 print_config_info toolset=$TOOLSET
         working-directory: ../boost-root/libs/config/test
       - name: Test
-        run: ../../../b2 toolset=$TOOLSET
+        run: ../../../b2 toolset=$TOOLSET variant=debug,release ${{ startsWith(matrix.compiler, 'g++-13') && 'address-sanitizer=norecover undefined-sanitizer=norecover' || '' }}
         working-directory: ../boost-root/libs/regex/test
   ubuntu-jammy-standalone:
     runs-on: ubuntu-22.04
@@ -170,6 +174,54 @@ jobs:
       - name: Test
         run: CXX=clang++-18 LIBRARIES="-licuuc -licudata -licui18n" ./test_clang.sh
         working-directory: ../boost-root/libs/regex/test/module
+  ubuntu-noble-clang:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [ clang++-16, clang++-17, clang++-18 ]
+        standard: [ c++11, c++14, c++17, c++20 ]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - uses: mstachniuk/ci-skip@v1
+        with:
+          commit-filter: '[skip ci];[ci skip];[CI SKIP];[SKIP CI];***CI SKIP***;***SKIP CI***;[windows];[Windows];[WINDOWS];[apple];[Apple];[APPLE]'
+          commit-filter-separator: ';'
+          fail-fast: true
+      - name: Set TOOLSET
+        run: echo ${{ matrix.compiler }} | awk '/^g/ { print "TOOLSET=gcc" } /^clang/ { print "TOOLSET=clang" }' >> $GITHUB_ENV
+      - name: Add repository
+        run: sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
+      - name: Install packages
+        run: sudo apt install clang-16 clang-17 clang-18
+      - name: Checkout main boost
+        run: git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
+      - name: Update tools/boostdep
+        run: git submodule update --init tools/boostdep
+        working-directory: ../boost-root
+      - name: Copy files
+        run: cp -r $GITHUB_WORKSPACE/* libs/regex
+        working-directory: ../boost-root
+      - name: Install deps
+        run: python tools/boostdep/depinst/depinst.py -I example -g "--jobs 3" regex
+        working-directory: ../boost-root
+      - name: Bootstrap
+        run: ./bootstrap.sh
+        working-directory: ../boost-root
+      - name: Generate headers
+        run: ./b2 headers
+        working-directory: ../boost-root
+      - name: Generate user config
+        run: 'echo "using $TOOLSET : : ${{ matrix.compiler }} : <cxxflags>-std=${{ matrix.standard }} ;" > ~/user-config.jam'
+        working-directory: ../boost-root
+      - name: Config info
+        run: ../../../b2 print_config_info toolset=$TOOLSET
+        working-directory: ../boost-root/libs/config/test
+      - name: Test
+        run: ../../../b2 toolset=$TOOLSET define=CI_SUPPRESS_KNOWN_ISSUES define=SLOW_COMPILER variant=debug,release ${{ startsWith(matrix.compiler, 'clang++-18') && 'address-sanitizer=norecover undefined-sanitizer=norecover' || '' }}
+        working-directory: ../boost-root/libs/regex/test
   macos:
     runs-on: macos-latest
     strategy:

--- a/include/boost/regex/v5/match_flags.hpp
+++ b/include/boost/regex/v5/match_flags.hpp
@@ -101,7 +101,7 @@ BOOST_REGEX_MODULE_EXPORT inline match_flags operator|(match_flags m1, match_fla
 BOOST_REGEX_MODULE_EXPORT inline match_flags operator^(match_flags m1, match_flags m2)
 { return static_cast<match_flags>(static_cast<std::int32_t>(m1) ^ static_cast<std::int32_t>(m2)); }
 BOOST_REGEX_MODULE_EXPORT inline match_flags operator~(match_flags m1)
-{ return static_cast<match_flags>(~static_cast<std::int32_t>(m1)); }
+{ return static_cast<match_flags>(~static_cast<std::int32_t>(m1) & static_cast<std::int32_t>(match_not_any)); }
 BOOST_REGEX_MODULE_EXPORT inline match_flags& operator&=(match_flags& m1, match_flags m2)
 { m1 = m1&m2; return m1; }
 BOOST_REGEX_MODULE_EXPORT inline match_flags& operator|=(match_flags& m1, match_flags m2)

--- a/include/boost/regex/v5/perl_matcher_non_recursive.hpp
+++ b/include/boost/regex/v5/perl_matcher_non_recursive.hpp
@@ -237,8 +237,8 @@ void perl_matcher<BidiIterator, Allocator, traits>::extend_stack()
       saved_state* backup_state;
       stack_base = static_cast<saved_state*>(get_mem_block());
       backup_state = reinterpret_cast<saved_state*>(reinterpret_cast<char*>(stack_base)+BOOST_REGEX_BLOCKSIZE);
-      saved_extra_block* block = static_cast<saved_extra_block*>(backup_state);
-      --block;
+      saved_extra_block* block = reinterpret_cast<saved_extra_block*>(
+         reinterpret_cast<std::uintptr_t>(backup_state) - sizeof(saved_extra_block));
       (void) new (block) saved_extra_block(m_stack_base, m_backup_state);
       m_stack_base = stack_base;
       m_backup_state = block;


### PR DESCRIPTION
@jzmaddock I closed my old PR and opened up this new one because rebasing was a little too messy.

This PR updates the CI to use ubsan and asan for the latest versions of gcc and clang on Linux. This PR also includes a couple of fixes flagged by the sanitizers.