### PR TITLE
fix overflow bug when attempting to access match results

### DIFF
--- a/include/boost/regex/v5/match_results.hpp
+++ b/include/boost/regex/v5/match_results.hpp
@@ -227,6 +227,10 @@ public:
    {
       if(m_is_singular && m_subs.empty())
          raise_logic_error();
+      
+      if (sub >= INT_MAX - 2 )
+         return m_null;
+
       sub += 2;
       if(sub < (int)m_subs.size() && (sub >= 0))
       {

--- a/include/boost/regex/v5/syntax_type.hpp
+++ b/include/boost/regex/v5/syntax_type.hpp
@@ -19,6 +19,8 @@
 #ifndef BOOST_REGEX_SYNTAX_TYPE_HPP
 #define BOOST_REGEX_SYNTAX_TYPE_HPP
 
+#include <boost/regex/config.hpp>
+
 namespace boost{
 namespace regex_constants{
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -138,4 +138,5 @@ run issue153.cpp : : : "<toolset>msvc:<linkflags>-STACK:2097152" ;
 run issue227.cpp ;
 run issue232.cpp ;
 run lookbehind_recursion_stress_test.cpp ;
+run regex_replace_overflow.cpp ;
 

--- a/test/regex_replace_overflow.cpp
+++ b/test/regex_replace_overflow.cpp
@@ -1,0 +1,29 @@
+#include <boost/regex.hpp>
+
+#include <iostream>
+#include <iterator>
+#include <sstream>
+#include <string>
+
+#include <boost/core/lightweight_test.hpp>
+
+int main() {
+   std::string format_string = "$2$2147483647";
+   boost::regex e2("(<)|(>)|(&)|\\r");
+
+   std::string in = 
+      "#include <iostream>"
+      ""
+      "int main() { std::cout << \"Hello, world!\\n\"; }";
+
+   std::ostringstream t( std::ios::out | std::ios::binary );
+   std::ostream_iterator<char, char> oi( t );
+
+   boost::regex_replace(oi, in.begin(), in.end(), e2, format_string,
+                        boost::match_default | boost::format_all);
+
+   std::string s(t.str());
+
+   BOOST_TEST(!s.empty());
+   return boost::report_errors();
+}


### PR DESCRIPTION
ubsan raises an error here on integer overflow when the format string includes a number that's set to INT_MAX. This passively fixes another asan failure caught by fuzzing.