### PR TITLE
fix integer overflow when parsing Perl-extended named backrefs

### DIFF
--- a/include/boost/regex/v5/basic_regex_parser.hpp
+++ b/include/boost/regex/v5/basic_regex_parser.hpp
@@ -898,6 +898,11 @@ escape_type_class_jump:
          }
          const charT* pc = m_position;
          std::intmax_t i = this->m_traits.toi(pc, m_end, 10);
+         if(i < 0 && !syn_end)
+         {
+            fail(regex_constants::error_backref, m_position - m_base);
+            return false;
+         }
          if((i < 0) && syn_end)
          {
             // Check for a named capture, get the leftmost one if there is more than one:

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -138,6 +138,7 @@ run issue153.cpp : : : "<toolset>msvc:<linkflags>-STACK:2097152" ;
 run issue227.cpp ;
 run issue232.cpp ;
 run issue244.cpp ;
+run issue245.cpp ;
 run lookbehind_recursion_stress_test.cpp ;
 run regex_replace_overflow.cpp ;
 

--- a/test/issue245.cpp
+++ b/test/issue245.cpp
@@ -1,0 +1,54 @@
+#include <boost/regex.hpp>
+
+#include <vector>
+#include <string>
+
+#include "test_macros.hpp"
+
+
+int main()
+{
+   // invalid because \k-- is an unterminated token
+   {
+      char const strdata[] = "\\k--00000000000000000000000000000000000000000000000000000000009223372036854775807\xff\xff\xff\xff\xff\xff\xff\xef""99999999999999999999999999999999999]999999999999999\x90";
+      std::string regex_string(strdata, strdata + sizeof(strdata) - 1);
+      BOOST_TEST_THROWS((boost::regex(regex_string)), boost::regex_error);
+   }
+   {
+      char const strdata[] = "\\k-00000000000000000000000000000000000000000000000000000000009223372036854775807\xff\xff\xff\xff\xff\xff\xff\xef""99999999999999999999999999999999999]999999999999999\x90";
+      std::string regex_string(strdata, strdata + sizeof(strdata) - 1);
+      BOOST_TEST_THROWS((boost::regex(regex_string)), boost::regex_error);
+   }
+   {
+      char const strdata[] = "\\k00000000000000000000000000000000000000000000000000000000009223372036854775807\xff\xff\xff\xff\xff\xff\xff\xef""99999999999999999999999999999999999]999999999999999\x90";
+      std::string regex_string(strdata, strdata + sizeof(strdata) - 1);
+      BOOST_TEST_THROWS((boost::regex(regex_string)), boost::regex_error);
+   }
+   {
+      char const strdata[] = "a(b*)c\\k{--1}d";
+      std::string regex_string(strdata, strdata + sizeof(strdata) - 1);
+      BOOST_TEST_THROWS((boost::regex(regex_string)), boost::regex_error);
+   }
+   {
+      char const strdata[] = "a(b*)c\\k-{-1}d";
+      std::string regex_string(strdata, strdata + sizeof(strdata) - 1);
+      BOOST_TEST_THROWS((boost::regex(regex_string)), boost::regex_error);
+   }
+   {
+      char const strdata[] = "\\k{--00000000000000000000000000000000000000000000000000000000009223372036854775807}\xff\xff\xff\xff\xff\xff\xff\xef""99999999999999999999999999999999999]999999999999999\x90";
+      std::string regex_string(strdata, strdata + sizeof(strdata) - 1);
+      BOOST_TEST_THROWS((boost::regex(regex_string)), boost::regex_error);
+   }
+   {
+      char const strdata[] = "\\k{-00000000000000000000000000000000000000000000000000000000009223372036854775807}\xff\xff\xff\xff\xff\xff\xff\xef""99999999999999999999999999999999999]999999999999999\x90";
+      std::string regex_string(strdata, strdata + sizeof(strdata) - 1);
+      BOOST_TEST_THROWS((boost::regex(regex_string)), boost::regex_error);
+   }
+   {
+      char const strdata[] = "\\k{00000000000000000000000000000000000000000000000000000000009223372036854775807}\xff\xff\xff\xff\xff\xff\xff\xef""99999999999999999999999999999999999]999999999999999\x90";
+      std::string regex_string(strdata, strdata + sizeof(strdata) - 1);
+      BOOST_TEST_THROWS((boost::regex(regex_string)), boost::regex_error);
+   }
+
+   return boost::report_errors();
+}


### PR DESCRIPTION
This issue comes to us as: https://issues.oss-fuzz.com/issues/42512790

Note that Perl seems to reject the regex better than us, flagging `\k--` as invalid in the first place.

We seem to treat `\g` and `\k` as literally the same, while Perl doesn't. Perl rejects `\g--` as unterminated token.

Our code seems to parse `\k-` appropriately, with the assumption that it's a valid synonym for `\g`, but then we run into overflow issues when parsing the number generated by the fuzzer which is `LONG_MIN`.

I'm not going to change the behavior of `\k` here but instead I simply just tried my hand at squashing the overflows.