### PR TITLE
Remove the implicit use of the regex_constants::match_any flag

### DIFF
--- a/include/boost/regex/v5/regex_match.hpp
+++ b/include/boost/regex/v5/regex_match.hpp
@@ -47,7 +47,7 @@ bool regex_match(iterator first, iterator last,
                  match_flag_type flags = match_default)
 {
    match_results<iterator> m;
-   return regex_match(first, last, m, e, flags | regex_constants::match_any);
+   return regex_match(first, last, m, e, flags);
 }
 //
 // query_match convenience interfaces:
@@ -75,7 +75,7 @@ inline bool regex_match(const charT* str,
                         match_flag_type flags = match_default)
 {
    match_results<const charT*> m;
-   return regex_match(str, str + traits::length(str), m, e, flags | regex_constants::match_any);
+   return regex_match(str, str + traits::length(str), m, e, flags);
 }
 
 BOOST_REGEX_MODULE_EXPORT template <class ST, class SA, class charT, class traits>
@@ -85,7 +85,7 @@ inline bool regex_match(const std::basic_string<charT, ST, SA>& s,
 {
    typedef typename std::basic_string<charT, ST, SA>::const_iterator iterator;
    match_results<iterator> m;
-   return regex_match(s.begin(), s.end(), m, e, flags | regex_constants::match_any);
+   return regex_match(s.begin(), s.end(), m, e, flags);
 }
 
 

--- a/include/boost/regex/v5/regex_search.hpp
+++ b/include/boost/regex/v5/regex_search.hpp
@@ -79,7 +79,7 @@ bool regex_search(BidiIterator first, BidiIterator last,
 
    match_results<BidiIterator> m;
    typedef typename match_results<BidiIterator>::allocator_type match_alloc_type;
-   BOOST_REGEX_DETAIL_NS::perl_matcher<BidiIterator, match_alloc_type, traits> matcher(first, last, m, e, flags | regex_constants::match_any, first);
+   BOOST_REGEX_DETAIL_NS::perl_matcher<BidiIterator, match_alloc_type, traits> matcher(first, last, m, e, flags, first);
    return BOOST_REGEX_DETAIL_NS::factory_find(matcher);
 }
 


### PR DESCRIPTION
Remove the implicit use of the regex_constants::match_any flag from regex_match and regex_search to improve performance in cases where match results are not needed. (#251)