### PR TITLE
Fix unchecked lower bound warning in get_default_error_string.

### DIFF
--- a/include/boost/regex/v5/regex_traits_defaults.hpp
+++ b/include/boost/regex/v5/regex_traits_defaults.hpp
@@ -148,7 +148,8 @@ inline const char*  get_default_error_string(regex_constants::error_type n)
       "Unknown error.",                                                     /* REG_E_UNKNOWN 21 error_unknown */
    };
 
-   return (n > ::boost::regex_constants::error_unknown) ? s_default_error_messages[::boost::regex_constants::error_unknown] : s_default_error_messages[n];
+   typedef typename std::make_unsigned<regex_constants::error_type>::type unsigned_type;
+   return (static_cast<unsigned_type>(n) > ::boost::regex_constants::error_unknown) ? s_default_error_messages[::boost::regex_constants::error_unknown] : s_default_error_messages[n];
 }
 
 inline regex_constants::syntax_type  get_default_syntax_type(char c)


### PR DESCRIPTION
This resolves #248 by fixing a build warning on MSVC that occurs in the `get_default_error_string` function. The warning is due to n being used as an index without its lower bound being checked. To fix this, I'm adding a cast to the bounds comparison so it is done as unsigned. That way negative values will show up as large positive values that exceed `error_unknown`. For consistency with the surrounding code, I used the same syntax to define the unsigned type as is used in the `is_extended` function on line 45.