### PR TITLE
Fix typo 'automoatically' in Standalone Mode section

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The full documentation is available on [boost.org](http://www.boost.org/doc/libs
 
  This library may now be used in "standalone" mode without the rest of the Boost C++ libraries, in order to do this you must either:
 
-* Have a C++17 compiler that supports __has_include, in this case if <boost/config.hpp> is not present then the library will automoatically enter standalone mode. Or:
+* Have a C++17 compiler that supports __has_include, in this case if <boost/config.hpp> is not present then the library will automatically enter standalone mode. Or:
 * Define BOOST_REGEX_STANDALONE when building.
 
 The main difference between the 2 modes, is that when Boost.Config is present the library will automatically configure itself around various compiler defects. In particular in order to use the library with exception support turned off, you will either need a copy of Boost.Config in your include path, or else manually define BOOST_NO_EXCEPTIONS when building.


### PR DESCRIPTION
Fixed a typo in the Standalone Mode section of the README.md file.