### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -10,7 +10,6 @@ constant boost_dependencies :
     /boost/concept_check//boost_concept_check
     /boost/config//boost_config
     /boost/predef//boost_predef
-    /boost/static_assert//boost_static_assert
     /boost/throw_exception//boost_throw_exception
     /boost/type_traits//boost_type_traits ;
 

--- a/test/cmake_subdir_test/CMakeLists.txt
+++ b/test/cmake_subdir_test/CMakeLists.txt
@@ -10,7 +10,6 @@ add_subdirectory(../.. boostorg/reegx)
 add_subdirectory(../../../config boostorg/config)
 add_subdirectory(../../../core boostorg/core)
 add_subdirectory(../../../assert boostorg/assert)
-add_subdirectory(../../../static_assert boostorg/static_assert)
 add_subdirectory(../../../throw_exception boostorg/throw_exception)
 add_subdirectory(../../../predef boostorg/predef)
 


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.