### PR TITLE
Fix template syntax in c_regex_traits.hpp

### DIFF
--- a/include/boost/regex/v5/c_regex_traits.hpp
+++ b/include/boost/regex/v5/c_regex_traits.hpp
@@ -59,7 +59,7 @@ namespace boost{
 BOOST_REGEX_MODULE_EXPORT template <class charT>
 struct c_regex_traits;
 
-BOOST_REGEX_MODULE_EXPORT template<>
+template<>
 struct c_regex_traits<char>
 {
    c_regex_traits(){}
@@ -104,7 +104,7 @@ private:
 };
 
 #ifndef BOOST_NO_WREGEX
-BOOST_REGEX_MODULE_EXPORT template<>
+template<>
 struct c_regex_traits<wchar_t>
 {
    c_regex_traits(){}


### PR DESCRIPTION
Do not export explicit specializations.
Reference to c++ specification: https://eel.is/c++draft/temp.expl.spec#2

MSVC 14.51 correctly complains about this syntax error.